### PR TITLE
Copy URL to clipboard instead of print it

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,233 @@
+# Created by https://www.gitignore.io/api/macos,python,pycharm+all
+# Edit at https://www.gitignore.io/?templates=macos,python,pycharm+all
+
+### macOS ###
+# General
+.DS_Store
+.AppleDouble
+.LSOverride
+
+# Icon must end with two \r
+Icon
+
+# Thumbnails
+._*
+
+# Files that might appear in the root of a volume
+.DocumentRevisions-V100
+.fseventsd
+.Spotlight-V100
+.TemporaryItems
+.Trashes
+.VolumeIcon.icns
+.com.apple.timemachine.donotpresent
+
+# Directories potentially created on remote AFP share
+.AppleDB
+.AppleDesktop
+Network Trash Folder
+Temporary Items
+.apdisk
+
+### PyCharm+all ###
+# Covers JetBrains IDEs: IntelliJ, RubyMine, PhpStorm, AppCode, PyCharm, CLion, Android Studio and WebStorm
+# Reference: https://intellij-support.jetbrains.com/hc/en-us/articles/206544839
+
+# User-specific stuff
+.idea/**/workspace.xml
+.idea/**/tasks.xml
+.idea/**/usage.statistics.xml
+.idea/**/dictionaries
+.idea/**/shelf
+
+# Generated files
+.idea/**/contentModel.xml
+
+# Sensitive or high-churn files
+.idea/**/dataSources/
+.idea/**/dataSources.ids
+.idea/**/dataSources.local.xml
+.idea/**/sqlDataSources.xml
+.idea/**/dynamic.xml
+.idea/**/uiDesigner.xml
+.idea/**/dbnavigator.xml
+
+# Gradle
+.idea/**/gradle.xml
+.idea/**/libraries
+
+# Gradle and Maven with auto-import
+# When using Gradle or Maven with auto-import, you should exclude module files,
+# since they will be recreated, and may cause churn.  Uncomment if using
+# auto-import.
+# .idea/modules.xml
+# .idea/*.iml
+# .idea/modules
+
+# CMake
+cmake-build-*/
+
+# Mongo Explorer plugin
+.idea/**/mongoSettings.xml
+
+# File-based project format
+*.iws
+
+# IntelliJ
+out/
+
+# mpeltonen/sbt-idea plugin
+.idea_modules/
+
+# JIRA plugin
+atlassian-ide-plugin.xml
+
+# Cursive Clojure plugin
+.idea/replstate.xml
+
+# Crashlytics plugin (for Android Studio and IntelliJ)
+com_crashlytics_export_strings.xml
+crashlytics.properties
+crashlytics-build.properties
+fabric.properties
+
+# Editor-based Rest Client
+.idea/httpRequests
+
+# Android studio 3.1+ serialized cache file
+.idea/caches/build_file_checksums.ser
+
+### PyCharm+all Patch ###
+# Ignores the whole .idea folder and all .iml files
+# See https://github.com/joeblau/gitignore.io/issues/186 and https://github.com/joeblau/gitignore.io/issues/360
+
+.idea/
+
+# Reason: https://github.com/joeblau/gitignore.io/issues/186#issuecomment-249601023
+
+*.iml
+modules.xml
+.idea/misc.xml
+*.ipr
+
+### Python ###
+# Byte-compiled / optimized / DLL files
+__pycache__/
+*.py[cod]
+*$py.class
+
+# C extensions
+*.so
+
+# Distribution / packaging
+.Python
+build/
+develop-eggs/
+dist/
+downloads/
+eggs/
+.eggs/
+lib/
+lib64/
+parts/
+sdist/
+var/
+wheels/
+share/python-wheels/
+*.egg-info/
+.installed.cfg
+*.egg
+MANIFEST
+
+# PyInstaller
+#  Usually these files are written by a python script from a template
+#  before PyInstaller builds the exe, so as to inject date/other infos into it.
+*.manifest
+*.spec
+
+# Installer logs
+pip-log.txt
+pip-delete-this-directory.txt
+
+# Unit test / coverage reports
+htmlcov/
+.tox/
+.nox/
+.coverage
+.coverage.*
+.cache
+nosetests.xml
+coverage.xml
+*.cover
+.hypothesis/
+.pytest_cache/
+
+# Translations
+*.mo
+*.pot
+
+# Django stuff:
+*.log
+local_settings.py
+db.sqlite3
+
+# Flask stuff:
+instance/
+.webassets-cache
+
+# Scrapy stuff:
+.scrapy
+
+# Sphinx documentation
+docs/_build/
+
+# PyBuilder
+target/
+
+# Jupyter Notebook
+.ipynb_checkpoints
+
+# IPython
+profile_default/
+ipython_config.py
+
+# pyenv
+.python-version
+
+# celery beat schedule file
+celerybeat-schedule
+
+# SageMath parsed files
+*.sage.py
+
+# Environments
+.env
+.venv
+env/
+venv/
+ENV/
+env.bak/
+venv.bak/
+
+# Spyder project settings
+.spyderproject
+.spyproject
+
+# Rope project settings
+.ropeproject
+
+# mkdocs documentation
+/site
+
+# mypy
+.mypy_cache/
+.dmypy.json
+dmypy.json
+
+# Pyre type checker
+.pyre/
+
+### Python Patch ###
+.venv/
+
+# End of https://www.gitignore.io/api/macos,python,pycharm+all

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,7 @@ python:
  - 3.7
 
 install:
- - pip install requests
+ - pip install -r requirements.txt
 
 script:
  - cd tests && ./check.sh

--- a/README.md
+++ b/README.md
@@ -48,6 +48,7 @@ optional arguments:
   -m message      message description for the transfer
   -f from         sender email
   -t to [to ...]  recipient emails
+  --clip          copy the upload URL to the clipboard
 ```
 
 The following example creates an `hello` text file with just `Hello world!` and
@@ -107,4 +108,6 @@ MD5 (hello) = 59ca0efa9f5633cb0371bbc0355478d8
 
 ## Dependencies
 
-transferwee needs [requests](http://python-requests.org/) package.
+transferwee depends on:
+- [requests](http://python-requests.org/) package;
+- [pyperclip](https://pypi.org/project/pyperclip/) package.

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,2 @@
+requests
+pyperclip

--- a/transferwee.py
+++ b/transferwee.py
@@ -45,6 +45,7 @@ import urllib.parse
 import zlib
 
 import requests
+import pyperclip
 
 
 WETRANSFER_API_URL = 'https://wetransfer.com/api/v4/transfers'
@@ -302,6 +303,8 @@ if __name__ == '__main__':
                     help='recipient emails')
     up.add_argument('files', nargs='+', type=str, metavar='file',
                     help='files to upload')
+    up.add_argument('--clip', default=False, action='store_true',
+                    help='copy the upload URL to the clipboard')
 
     args = ap.parse_args()
 
@@ -315,6 +318,13 @@ if __name__ == '__main__':
         exit(0)
 
     if args.action == 'upload':
+        shortened_url = upload(args.files, args.m, args.f, args.t)
+
+        # Copy shortened URL to clipboard and exit
+        if args.clip:
+            pyperclip.copy(shortened_url)
+            exit(0)
+
         print(upload(args.files, args.m, args.f, args.t))
         exit(0)
 


### PR DESCRIPTION
This pull request add option `--clip` to enable copying of WeTransfer shortened URL to clipboard. When `--clip` is set, no output will be printed to the console.

I'm glad to discuss this change because it adds a dependency to package [pyperclip](https://pypi.org/project/pyperclip/).