### PR TITLE
added display name option to trasfer

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ Otherwise the link upload will be used.
 
 ```
 % transferwee upload -h
-usage: transferwee upload [-h] [-n name] [-m message] [-f from] [-t to [to ...]]
+usage: transferwee upload [-h] [-n display_name] [-m message] [-f from] [-t to [to ...]]
                           file [file ...]
 
 positional arguments:

--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ positional arguments:
 
 optional arguments:
   -h, --help      show this help message and exit
-  -m name         display name for the transfer
+  -n display_name         display name for the transfer
   -m message      message description for the transfer
   -f from         sender email
   -t to [to ...]  recipient emails

--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ Otherwise the link upload will be used.
 
 ```
 % transferwee upload -h
-usage: transferwee upload [-h] [-m message] [-f from] [-t to [to ...]]
+usage: transferwee upload [-h] [-n name] [-m message] [-f from] [-t to [to ...]]
                           file [file ...]
 
 positional arguments:
@@ -46,6 +46,7 @@ positional arguments:
 
 optional arguments:
   -h, --help      show this help message and exit
+  -m name         display name for the transfer
   -m message      message description for the transfer
   -f from         sender email
   -t to [to ...]  recipient emails

--- a/transferwee.py
+++ b/transferwee.py
@@ -182,7 +182,7 @@ def _prepare_email_upload(filenames: List[str], display_name: str, message: str,
     j = {
         "files": [_file_name_and_size(f) for f in filenames],
         "from": sender,
-        "display_name": name,
+        "display_name": display_name,
         "message": message,
         "recipients": recipients,
         "ui_language": "en",

--- a/transferwee.py
+++ b/transferwee.py
@@ -209,7 +209,7 @@ def _verify_email_upload(transfer_id: str, session: requests.Session) -> str:
     return r.json()
 
 
-def _prepare_link_upload(filenames: List[str], name: str, message: str,
+def _prepare_link_upload(filenames: List[str], display_name: str, message: str,
                          session: requests.Session) -> str:
     """Given a list of filenames and a message prepare for the link upload.
 

--- a/transferwee.py
+++ b/transferwee.py
@@ -386,7 +386,7 @@ if __name__ == '__main__':
         exit(0)
 
     if args.action == 'upload':
-        print(upload(args.files,args.n,args.m, args.f, args.t))
+        print(upload(args.files,args.n, args.m, args.f, args.t))
         exit(0)
 
     # No action selected, print help message

--- a/transferwee.py
+++ b/transferwee.py
@@ -330,7 +330,7 @@ def upload(files: List[str], name:str = '', message: str = '', sender: str = Non
     if sender and recipients:
         # email upload
         transfer_id = \
-            _prepare_email_upload(files, name, message, sender, recipients, s)['id']
+            _prepare_email_upload(files, display_name, message, sender, recipients, s)['id']
         _verify_email_upload(transfer_id, s)
     else:
         # link upload

--- a/transferwee.py
+++ b/transferwee.py
@@ -300,7 +300,7 @@ def upload(files: List[str], name:str = '', message: str = '', sender: str = Non
     """Given a list of files upload them and return the corresponding URL.
 
     Also accepts optional parameters:
-     - `name': name used as a display name of the transfer
+     - `display_name': display name used when downloading a transfer
      - `message': message used as a description of the transfer
      - `sender': email address used to receive an ACK if the upload is
                  successfull. For every download by the recipients an email

--- a/transferwee.py
+++ b/transferwee.py
@@ -295,7 +295,7 @@ def _finalize_upload(transfer_id: str, session: requests.Session) -> str:
     return r.json()
 
 
-def upload(files: List[str], name:str = '', message: str = '', sender: str = None,
+def upload(files: List[str], display_name: str = '', message: str = '', sender: str = None,
            recipients: List[str] = []) -> str:
     """Given a list of files upload them and return the corresponding URL.
 

--- a/transferwee.py
+++ b/transferwee.py
@@ -171,7 +171,7 @@ def _prepare_session() -> requests.Session:
     return s
 
 
-def _prepare_email_upload(filenames: List[str], name: str, message: str,
+def _prepare_email_upload(filenames: List[str], display_name: str, message: str,
                           sender: str, recipients: List[str],
                           session: requests.Session) -> str:
     """Given a list of filenames, message a sender and recipients prepare for

--- a/transferwee.py
+++ b/transferwee.py
@@ -364,7 +364,7 @@ if __name__ == '__main__':
 
     # upload subcommand
     up = sp.add_parser('upload', help='upload files')
-    up.add_argument('-n', type=str, default='', metavar='name',
+    up.add_argument('-n', type=str, default='', metavar='display_name',
                     help='display name for the transfer')
     up.add_argument('-m', type=str, default='', metavar='message',
                     help='message description for the transfer')

--- a/transferwee.py
+++ b/transferwee.py
@@ -171,7 +171,7 @@ def _prepare_session() -> requests.Session:
     return s
 
 
-def _prepare_email_upload(filenames: List[str], message: str,
+def _prepare_email_upload(filenames: List[str], name: str, message: str,
                           sender: str, recipients: List[str],
                           session: requests.Session) -> str:
     """Given a list of filenames, message a sender and recipients prepare for
@@ -182,6 +182,7 @@ def _prepare_email_upload(filenames: List[str], message: str,
     j = {
         "files": [_file_name_and_size(f) for f in filenames],
         "from": sender,
+        "display_name": name,
         "message": message,
         "recipients": recipients,
         "ui_language": "en",
@@ -208,7 +209,7 @@ def _verify_email_upload(transfer_id: str, session: requests.Session) -> str:
     return r.json()
 
 
-def _prepare_link_upload(filenames: List[str], message: str,
+def _prepare_link_upload(filenames: List[str], name: str, message: str,
                          session: requests.Session) -> str:
     """Given a list of filenames and a message prepare for the link upload.
 
@@ -216,6 +217,7 @@ def _prepare_link_upload(filenames: List[str], message: str,
     """
     j = {
         "files": [_file_name_and_size(f) for f in filenames],
+        "display_name": name,
         "message": message,
         "ui_language": "en",
     }
@@ -293,11 +295,12 @@ def _finalize_upload(transfer_id: str, session: requests.Session) -> str:
     return r.json()
 
 
-def upload(files: List[str], message: str = '', sender: str = None,
+def upload(files: List[str], name:str = '', message: str = '', sender: str = None,
            recipients: List[str] = []) -> str:
     """Given a list of files upload them and return the corresponding URL.
 
     Also accepts optional parameters:
+     - `name': name used as a display name of the transfer
      - `message': message used as a description of the transfer
      - `sender': email address used to receive an ACK if the upload is
                  successfull. For every download by the recipients an email
@@ -327,11 +330,11 @@ def upload(files: List[str], message: str = '', sender: str = None,
     if sender and recipients:
         # email upload
         transfer_id = \
-            _prepare_email_upload(files, message, sender, recipients, s)['id']
+            _prepare_email_upload(files, name, message, sender, recipients, s)['id']
         _verify_email_upload(transfer_id, s)
     else:
         # link upload
-        transfer_id = _prepare_link_upload(files, message, s)['id']
+        transfer_id = _prepare_link_upload(files, name, message, s)['id']
 
     for f in files:
         file_id = _prepare_file_upload(transfer_id, f, s)['id']
@@ -361,6 +364,8 @@ if __name__ == '__main__':
 
     # upload subcommand
     up = sp.add_parser('upload', help='upload files')
+    up.add_argument('-n', type=str, default='', metavar='name',
+                    help='display name for the transfer')
     up.add_argument('-m', type=str, default='', metavar='message',
                     help='message description for the transfer')
     up.add_argument('-f', type=str, metavar='from', help='sender email')
@@ -381,7 +386,7 @@ if __name__ == '__main__':
         exit(0)
 
     if args.action == 'upload':
-        print(upload(args.files, args.m, args.f, args.t))
+        print(upload(args.files,args.n,args.m, args.f, args.t))
         exit(0)
 
     # No action selected, print help message

--- a/transferwee.py
+++ b/transferwee.py
@@ -334,7 +334,7 @@ def upload(files: List[str], name:str = '', message: str = '', sender: str = Non
         _verify_email_upload(transfer_id, s)
     else:
         # link upload
-        transfer_id = _prepare_link_upload(files, name, message, s)['id']
+        transfer_id = _prepare_link_upload(files, display_name, message, s)['id']
 
     for f in files:
         file_id = _prepare_file_upload(transfer_id, f, s)['id']

--- a/transferwee.py
+++ b/transferwee.py
@@ -217,7 +217,7 @@ def _prepare_link_upload(filenames: List[str], display_name: str, message: str,
     """
     j = {
         "files": [_file_name_and_size(f) for f in filenames],
-        "display_name": name,
+        "display_name": display_name,
         "message": message,
         "ui_language": "en",
     }


### PR DESCRIPTION
## Display Name Option 
 I added the new option for upload operation.   ```-n display name ```
Without display name When you upload a file with  -m option you will see if you open the transfer link  "Untitled transfer" 
```bash `transferee.py  upload -m "it is a message too" hello ```
<img width="317" alt="Screen Shot 2021-12-14 at 16 43 04" src="https://user-images.githubusercontent.com/50212369/146010725-19853d42-174c-4836-aa60-8e89cc6598c7.png">

So I added a new option for the upload operation it is display name [-n]
With display name option   ```bash transferee.py  upload -n "transfered with this display name" -m "it is a message too" hello ``` , You will se the transfer link with display name like that 👍  
<img width="317" alt="Screen Shot 2021-12-14 at 16 44 35" src="https://user-images.githubusercontent.com/50212369/146011291-ed21a7ee-e3cf-4e3e-ae57-e72e15965c10.png">

thanks for the creating this project 🙏🏻