### PR TITLE
upload: Permit to set transfer title (AKA display name)

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,17 +38,17 @@ Otherwise the link upload will be used.
 
 ```
 % transferwee upload -h
-usage: transferwee upload [-h] [-m message] [-f from] [-t to [to ...]]
-                          file [file ...]
+usage: transferwee upload [-h] [-n display_name] [-m message] [-f from] [-t to [to ...]] file [file ...]
 
 positional arguments:
-  file            files to upload
+  file             files to upload
 
 optional arguments:
-  -h, --help      show this help message and exit
-  -m message      message description for the transfer
-  -f from         sender email
-  -t to [to ...]  recipient emails
+  -h, --help       show this help message and exit
+  -n display_name  display name for the transfer
+  -m message       message description for the transfer
+  -f from          sender email
+  -t to [to ...]   recipient emails
 ```
 
 The following example creates an `hello` text file with just `Hello world!` and

--- a/tests/check.sh
+++ b/tests/check.sh
@@ -20,7 +20,7 @@ echo "Creating a test file..."
 echo "Hello world!" > "${testtmpfile}"
 
 echo "Uploading the test file..."
-url=$(${TRANSFERWEE} upload -m 'Just a text file with the mandatory message...' "${testtmpfile}")
+url=$(${TRANSFERWEE} upload -n 'Nice transfer title' -m 'Just a text file with the mandatory message...' "${testtmpfile}")
 echo "test file uploaded as ${url}"
 
 echo "Renaming original test file..."


### PR DESCRIPTION
Add support to optionally set the title (AKA display name) of a
transfer via `-n' option.

This is just a rebase of #17, merging all the commits together and
adding a couple of fixes.
