### PR TITLE
Add initial logging and introduce a `-v` option

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,17 +38,18 @@ Otherwise the link upload will be used.
 
 ```
 % transferwee upload -h
-usage: transferwee upload [-h] [-n display_name] [-m message] [-f from] [-t to [to ...]] file [file ...]
+usage: transferwee upload [-h] [-n display_name] [-m message] [-f from] [-t to [to ...]] [-v] file [file ...]
 
 positional arguments:
   file             files to upload
 
 optional arguments:
   -h, --help       show this help message and exit
-  -n display_name  display name for the transfer
+  -n display_name  title for the transfer
   -m message       message description for the transfer
   -f from          sender email
   -t to [to ...]   recipient emails
+  -v               get verbose/debug logging
 ```
 
 The following example creates an `hello` text file with just `Hello world!` and
@@ -84,7 +85,7 @@ The URL supported are the ones in the form:
 
 ```
 % transferwee download -h
-usage: transferwee download [-h] [-g] [-o file] url [url ...]
+usage: transferwee download [-h] [-g] [-o file] [-v] url [url ...]
 
 positional arguments:
   url         URL (we.tl/... or wetransfer.com/downloads/...)
@@ -93,6 +94,7 @@ optional arguments:
   -h, --help  show this help message and exit
   -g          only print the direct link (without downloading it)
   -o file     output file to be used
+  -v          get verbose/debug logging
 ```
 
 The following example download the `hello` text file that was uploaded in the

--- a/tests/check.sh
+++ b/tests/check.sh
@@ -20,7 +20,7 @@ echo "Creating a test file..."
 echo "Hello world!" > "${testtmpfile}"
 
 echo "Uploading the test file..."
-url=$(${TRANSFERWEE} upload -n 'Nice transfer title' -m 'Just a text file with the mandatory message...' "${testtmpfile}")
+url=$(${TRANSFERWEE} upload -v -n 'Nice transfer title' -m 'Just a text file with the mandatory message...' "${testtmpfile}")
 echo "test file uploaded as ${url}"
 
 echo "Renaming original test file..."
@@ -30,7 +30,7 @@ echo "Waiting 10 seconds before downloading the file..."
 sleep 10
 
 echo "Downloading the test file via ${url}..."
-${TRANSFERWEE} download "${url}"
+${TRANSFERWEE} download -v "${url}"
 
 echo "Checking if the uploaded file and downloaded file are the same..."
 cmp "${testtmpfile}.orig" "${testtmpfile}"


### PR DESCRIPTION
Add a package logger and start logging in the various exposed functions possible helpful debug information.

Add a `-v` option to both the download and upload commands so debugging can be turned on and inspected also while using transferwee as a tool.

Convert the test to always use the `-v` option.
