### PR TITLE
Do not run workflow twice in PR

### DIFF
--- a/.github/workflows/python-app.yml
+++ b/.github/workflows/python-app.yml
@@ -2,6 +2,8 @@ name: Check and test transferwee
 
 on:
   push:
+    branches:
+      - master
   pull_request:
   schedule:
     - cron:  '0 0 * * *'

--- a/.github/workflows/semgrep.yml
+++ b/.github/workflows/semgrep.yml
@@ -1,6 +1,10 @@
 name: Semgrep
 
-on: [push, pull_request]
+on:
+  push:
+    branches:
+      - master
+  pull_request:
 
 jobs:
   semgrep:


### PR DESCRIPTION
Avoid overlapping events in order to run the GitHub Actions workflow only once.
