### PR TITLE
Enable PYTHONDEVMODE and PYTHONTRACEMALLOC

### DIFF
--- a/.github/workflows/python-app.yml
+++ b/.github/workflows/python-app.yml
@@ -45,5 +45,8 @@ jobs:
         mypy .
     - name: Test transferwee
       shell: bash
+      env:
+        PYTHONDEVMODE: 1
+        PYTHONTRACEMALLOC: 1
       run: |
         cd tests && ./check.sh


### PR DESCRIPTION
Run tests in Python development mode and also enable more expensive tracemalloc checks to spot possibly several problems like improper resource allocations.
