### PR TITLE
Switch to Python 3.10

### DIFF
--- a/.github/workflows/python-app.yml
+++ b/.github/workflows/python-app.yml
@@ -13,10 +13,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v2
-    - name: Set up Python 3.8
+    - name: Set up Python 3.10
       uses: actions/setup-python@v2
       with:
-        python-version: 3.8
+        python-version: '3.10'
     - name: Cache pip
       uses: actions/cache@v2
       with:


### PR DESCRIPTION
Probably more common than 3.8 these days.

transferwee itself should be still compatible with all supported 3.x
versions.
