### PR TITLE
Mark `upload()` `sender` and `recipients` as optional

### DIFF
--- a/transferwee.py
+++ b/transferwee.py
@@ -320,8 +320,9 @@ def _finalize_upload(transfer_id: str, session: requests.Session) -> dict:
     return r.json()
 
 
-def upload(files: List[str], display_name: str = '', message: str = '', sender: str = None,
-           recipients: List[str] = []) -> str:
+def upload(files: List[str], display_name: str = '', message: str = '',
+           sender: Optional[str] = None,
+           recipients: Optional[List[str]] = []) -> str:
     """Given a list of files upload them and return the corresponding URL.
 
     Also accepts optional parameters:


### PR DESCRIPTION
Add `Optional` annotations both to sender and recipients per PEP 484 that prohibits implicit optional.

Catched by recent `mypy` that has changed default to `no_implicit_optional=True`.
