### PR TITLE
Spoof User-Agent string

### DIFF
--- a/.github/workflows/python-app.yml
+++ b/.github/workflows/python-app.yml
@@ -33,6 +33,9 @@ jobs:
         pip install flake8
         pip install mypy
         pip install requests
+    - name: Install Tor
+      run: |
+        sudo apt-get install tor
     - name: Lint with flake8
       run: |
         # stop the build if there are Python syntax errors or undefined names
@@ -49,4 +52,4 @@ jobs:
         PYTHONDEVMODE: 1
         PYTHONTRACEMALLOC: 1
       run: |
-        cd tests && ./check.sh
+        cd tests && torify ./check.sh

--- a/transferwee.py
+++ b/transferwee.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python3
 
 #
-# Copyright (c) 2018-2022 Leonardo Taccari
+# Copyright (c) 2018-2023 Leonardo Taccari
 # All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without


### PR DESCRIPTION
Since 2023-01-20 wetransfer.com started to block default requests User-Agent string.

Switch to last Firefox ESR User-Agent to avoid that.

Should fix #33.

Problem analyzed by @peterk, thanks!
