### PR TITLE
Adjust upload of files to new API

### DIFF
--- a/transferwee.py
+++ b/transferwee.py
@@ -158,14 +158,15 @@ def download(url: str, file: str = '') -> None:
 
 
 def _file_name_and_size(file: str) -> dict:
-    """Given a file, prepare the "name" and "size" dictionary.
+    """Given a file, prepare the "item_type", "name" and "size" dictionary.
 
-    Return a dictionary with "name" and "size" keys.
+    Return a dictionary with "item_type", "name" and "size" keys.
     """
     filename = os.path.basename(file)
     filesize = os.path.getsize(file)
 
     return {
+        "item_type": "file",
         "name": filename,
         "size": filesize
     }


### PR DESCRIPTION
The upload of files completely changed and now it seems that a WeTransfer Storm API and S3 upload are used.

Adjust the code to call this API (based on reverse engineering of link upload transfer).

At the moment the eu-west-1 region is hardcoded but we can probably use other regions as well but some way should be investigated to retrieve such regions and use the nearest one (a big XXX comment documents that).

Tested only with a single file upload, both with link and email uploads.

Should close issue #38.
