### PR TITLE
Update transferwee.py. Fixes #40

### DIFF
--- a/transferwee.py
+++ b/transferwee.py
@@ -187,16 +187,18 @@ def _prepare_session() -> Optional[requests.Session]:
     requests.
     """
     s = requests.Session()
-    s.headers.update({'User-Agent': WETRANSFER_USER_AGENT})
+    s.headers.update({
+        'User-Agent': WETRANSFER_USER_AGENT,
+        'x-requested-with': 'XMLHttpRequest'
+    })
     r = s.get('https://wetransfer.com/')
     m = re.search('name="csrf-token" content="([^"]+)"', r.text)
-    if not m:
-        logger.error(f'Could not find any csrf-token')
-        return None
-    s.headers.update({
-        'x-csrf-token': m.group(1),
-        'x-requested-with': 'XMLHttpRequest',
-    })
+    if m:
+        s.headers.update({
+            'x-csrf-token': m.group(1),
+        })
+    else:
+        logger.info('Could not find any csrf-token')
 
     return s
 


### PR DESCRIPTION
Depending on the origin the parsed csrf token may not be needed. This fix updates the session only if there was a csrf token meta element in the html.