### PR TITLE
Reformat/restyle the code to match Black code style and enforce it by running as part of the CI/CD pipelines

### DIFF
--- a/.github/workflows/python-app.yml
+++ b/.github/workflows/python-app.yml
@@ -32,6 +32,7 @@ jobs:
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip
+        pip install black
         pip install flake8
         pip install mypy
         pip install requests
@@ -44,6 +45,9 @@ jobs:
         flake8 . --select=E9,F63,F7,F82 --show-source
         # exit-zero treats all errors as warnings.
         flake8 . --exit-zero --max-complexity=10
+    - name: Check code style via Black
+      run: |
+        black --check .
     - name: Static type checking via mypy
       run: |
         mypy --non-interactive --install-types .

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,3 @@
+[tool.black]
+# honor PEP 8
+line-length = 79


### PR DESCRIPTION
This PR enable running [black](https://black.readthedocs.io/en/stable/) as part of the CI/CD pipeline and reformat `transferwee` with the current Black code style.

The only non-default change that was adjusted is the line length that was reduced to 79 to respect PEP 8 and being <= 80 characters is nicer for most environments as well.
