### PR TITLE
Enhance all dict type annotations and enable `mypy --strict`-er checks (except for `no-any-return`!)

### DIFF
--- a/.github/workflows/python-app.yml
+++ b/.github/workflows/python-app.yml
@@ -51,7 +51,7 @@ jobs:
     - name: Static type checking via mypy
       run: |
         mypy --non-interactive --install-types .
-        mypy .
+        mypy --strict --disable-error-code no-any-return .
     - name: Test transferwee
       shell: bash
       env:

--- a/transferwee.py
+++ b/transferwee.py
@@ -38,7 +38,7 @@ files from a `we.tl' or `wetransfer.com/downloads' URLs and upload files that
 will be shared via emails or link.
 """
 
-from typing import List, Optional
+from typing import Any, List, Optional, Union
 import binascii
 import functools
 import hashlib
@@ -172,7 +172,7 @@ def download(url: str, file: str = "") -> None:
             f.write(chunk)
 
 
-def _file_name_and_size(file: str) -> dict:
+def _file_name_and_size(file: str) -> dict[str, Union[int, str]]:
     """Given a file, prepare the "item_type", "name" and "size" dictionary.
 
     Return a dictionary with "item_type", "name" and "size" keys.
@@ -223,7 +223,7 @@ def _prepare_email_upload(
     sender: str,
     recipients: List[str],
     session: requests.Session,
-) -> dict:
+) -> dict[Any, Any]:
     """Given a list of filenames, message a sender and recipients prepare for
     the email upload.
 
@@ -242,7 +242,9 @@ def _prepare_email_upload(
     return r.json()
 
 
-def _verify_email_upload(transfer_id: str, session: requests.Session) -> dict:
+def _verify_email_upload(
+    transfer_id: str, session: requests.Session
+) -> dict[Any, Any]:
     """Given a transfer_id, read the code from standard input.
 
     Return the parsed JSON response.
@@ -265,7 +267,7 @@ def _prepare_link_upload(
     display_name: str,
     message: str,
     session: requests.Session,
-) -> dict:
+) -> dict[Any, Any]:
     """Given a list of filenames and a message prepare for the link upload.
 
     Return the parsed JSON response.
@@ -281,7 +283,9 @@ def _prepare_link_upload(
     return r.json()
 
 
-def _storm_preflight_item(file: str) -> dict:
+def _storm_preflight_item(
+    file: str,
+) -> dict[str, Union[List[dict[str, int]], str]]:
     """Given a file, prepare the item block dictionary.
 
     Return a dictionary with "blocks", "item_type" and "path" keys.
@@ -296,7 +300,9 @@ def _storm_preflight_item(file: str) -> dict:
     }
 
 
-def _storm_preflight(authorization: str, filenames: List[str]) -> dict:
+def _storm_preflight(
+    authorization: str, filenames: List[str]
+) -> dict[Any, Any]:
     """Given an Authorization token and filenames do preflight for upload.
 
     Return the parsed JSON response.
@@ -335,7 +341,7 @@ def _md5(file: str) -> str:
     return h.hexdigest()
 
 
-def _storm_prepare_item(file: str) -> dict:
+def _storm_prepare_item(file: str) -> dict[str, Union[int, str]]:
     """Given a file, prepare the block for blocks dictionary.
 
     Return a dictionary with "content_length" and "content_md5_hex" keys.
@@ -345,7 +351,7 @@ def _storm_prepare_item(file: str) -> dict:
     return {"content_length": filesize, "content_md5_hex": _md5(file)}
 
 
-def _storm_prepare(authorization: str, filenames: List[str]) -> dict:
+def _storm_prepare(authorization: str, filenames: List[str]) -> dict[Any, Any]:
     """Given an Authorization token and filenames prepare for block uploads.
 
     Return the parsed JSON response.
@@ -373,7 +379,9 @@ def _storm_prepare(authorization: str, filenames: List[str]) -> dict:
     return r.json()
 
 
-def _storm_finalize_item(file: str, block_id: str) -> dict:
+def _storm_finalize_item(
+    file: str, block_id: str
+) -> dict[str, Union[List[str], str]]:
     """Given a file and block_id prepare the item block dictionary.
 
     Return a dictionary with "block_ids", "item_type" and "path" keys.
@@ -396,7 +404,7 @@ def _storm_finalize_item(file: str, block_id: str) -> dict:
 
 def _storm_finalize(
     authorization: str, filenames: List[str], block_ids: List[str]
-) -> dict:
+) -> dict[Any, Any]:
     """Given an Authorization token, filenames and block ids finalize upload.
 
     Return the parsed JSON response.
@@ -469,7 +477,9 @@ def _storm_upload(url: str, file: str) -> None:
         )
 
 
-def _finalize_upload(transfer_id: str, session: requests.Session) -> dict:
+def _finalize_upload(
+    transfer_id: str, session: requests.Session
+) -> dict[Any, Any]:
     """Given a transfer_id finalize the upload.
 
     Return the parsed JSON response.


### PR DESCRIPTION
This PR enhance all dict type annotations - pointed out via `mypy --strict .` - and switch the `mypy` invocation to a `strict`-er one but permits the `no-any-return` because we rely on that for JSON not controlled by us.

For possible further details please give a look to each commit message.
