### PR TITLE
Retry tests with an exponential backoff mechanism

### DIFF
--- a/.github/workflows/python-app.yml
+++ b/.github/workflows/python-app.yml
@@ -58,4 +58,19 @@ jobs:
         PYTHONDEVMODE: 1
         PYTHONTRACEMALLOC: 1
       run: |
-        cd tests && torify ./check.sh
+        e=0
+        sleep_time=1
+        factor=2
+        cd tests 
+        until torify ./check.sh ; do
+          e=$?
+          if [ "${sleep_time}" -gt 64 ]; then
+            echo "Tried too much times"
+            break
+          fi
+          echo "Tests failed with exit code ${e}"
+          echo "Retrying in ${sleep_time}"
+          sleep ${sleep_time}
+          sleep_time=$((sleep_time * factor))
+        done
+        exit $e


### PR DESCRIPTION
Unfortunately tests are pretty flacky... Sometimes Tor is not ready other times probably WeTransfer is not happy about us.

Try to introduce an exponential backoff mechanism and retry tests several times to possibly workaround that.

This could be a bad idea!: i.e. maybe it will just fail several times in a row! (but maybe not, let's try to use more brute-force in that case!)
