### PR TITLE
Don't exit with non-0 exit status when everything goes well

### DIFF
--- a/.github/workflows/python-app.yml
+++ b/.github/workflows/python-app.yml
@@ -58,7 +58,6 @@ jobs:
         PYTHONDEVMODE: 1
         PYTHONTRACEMALLOC: 1
       run: |
-        e=0
         sleep_time=1
         factor=2
         cd tests 
@@ -66,11 +65,10 @@ jobs:
           e=$?
           if [ "${sleep_time}" -gt 64 ]; then
             echo "Tried too much times"
-            break
+            exit $e
           fi
           echo "Tests failed with exit code ${e}"
           echo "Retrying in ${sleep_time}"
           sleep ${sleep_time}
           sleep_time=$((sleep_time * factor))
         done
-        exit $e


### PR DESCRIPTION
By saving the `e` - given that it is (re)assigned everytime we hit the until loop, if for any reason the 1st try went bad but a try later went well we exited with non-0 exit status because it was the saved one.

Given that we will exit only when retrying for too much times just replace the `break` with an `exit` of the last saved status (that should be non-0 and this time should be right!).
