### PR TITLE
Switch to latest actions/checkout@v3

### DIFF
--- a/.github/workflows/python-app.yml
+++ b/.github/workflows/python-app.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Checkout code
-      uses: actions/checkout@v2
+      uses: actions/checkout@v3
     - name: Set up Python 3.10
       uses: actions/setup-python@v2
       with:


### PR DESCRIPTION
The only significant change is that it uses node16 runtime by default.

Node.js 12 actions are deprecated.
