### PR TITLE
Update to actions/setup-python@v4

### DIFF
--- a/.github/workflows/python-app.yml
+++ b/.github/workflows/python-app.yml
@@ -16,7 +16,7 @@ jobs:
     - name: Checkout code
       uses: actions/checkout@v3
     - name: Set up Python 3.10
-      uses: actions/setup-python@v2
+      uses: actions/setup-python@v4
       with:
         python-version: '3.10'
     - name: Cache pip


### PR DESCRIPTION
actions/setup-python@v3 switched default runtime to node16 that should solve a deprecation warning.

Apart that - at least for transferwee usage - no other change is expected.
