### PR TITLE
Update to actions/cache@v3

### DIFF
--- a/.github/workflows/python-app.yml
+++ b/.github/workflows/python-app.yml
@@ -20,7 +20,7 @@ jobs:
       with:
         python-version: '3.10'
     - name: Cache pip
-      uses: actions/cache@v2
+      uses: actions/cache@v3
       with:
         # This path is specific to Ubuntu
         path: ~/.cache/pip


### PR DESCRIPTION
This update to node16 runtime (Node.js 12 actions are deprecated).

No other changes should affect the usage by transferwee.
