### PR TITLE
Switch back to test without Tor

### DIFF
--- a/.github/workflows/python-app.yml
+++ b/.github/workflows/python-app.yml
@@ -36,9 +36,6 @@ jobs:
         pip install flake8
         pip install mypy
         pip install requests
-    - name: Install Tor
-      run: |
-        sudo apt-get install tor
     - name: Lint with flake8
       run: |
         # stop the build if there are Python syntax errors or undefined names
@@ -61,7 +58,7 @@ jobs:
         sleep_time=1
         factor=2
         cd tests 
-        until torify ./check.sh ; do
+        until ./check.sh ; do
           e=$?
           if [ "${sleep_time}" -gt 64 ]; then
             echo "Tried too much times"


### PR DESCRIPTION
Tests were failing much more probably due actual real issues, not banning.

At least with Tor we had some chances to pick up `eu-west-1` `WETRANSFER_STORM_*` URLs that probably never happens without Tor from GitHub Actions default worker machines. This should be fixed by 5a3364424b329b23371f81ec89f19dd533df7d37 though.
