### PR TITLE
Use actual default branch

### DIFF
--- a/.github/workflows/conftest.yml
+++ b/.github/workflows/conftest.yml
@@ -3,7 +3,7 @@ name: Validate via personal conftest policies
 'on':
   push:
     branches:
-      - main
+      - master
   pull_request:
 
 jobs:


### PR DESCRIPTION
The default branch of this repository is `master`, not `main`.

Now conftest GitHub Actions workflow should be run when merging on `master` as well and as expected and consistent with other repositories.
