### PR TITLE
Add GitHub Workflow to generate transferwee.exe

### DIFF
--- a/.github/workflows/windows_exe_release.yml
+++ b/.github/workflows/windows_exe_release.yml
@@ -1,0 +1,27 @@
+name: Package transferwee with Pyinstaller
+
+on:
+  push:
+    branches: [ master ]
+  pull_request:
+    branches: [ master ]
+
+jobs:
+  buildexe:
+    name: Build transferwee.exe
+    runs-on: ubuntu-latest
+
+    steps:
+    - name: Checkout code
+      uses: actions/checkout@v2
+
+    - name: Package transferwee
+      uses: JackMcKew/pyinstaller-action-windows@main
+      with:
+        path: .
+
+    - name: Upload transferwee.exe artifact
+      uses: actions/upload-artifact@v2
+      with:
+        name: transferwee
+        path: ./dist/windows

--- a/transferwee.spec
+++ b/transferwee.spec
@@ -1,0 +1,36 @@
+# -*- mode: python ; coding: utf-8 -*-
+
+
+a = Analysis(
+    ['transferwee.py'],
+    pathex=[],
+    binaries=[],
+    datas=[],
+    hiddenimports=[],
+    hookspath=[],
+    runtime_hooks=[],
+    excludes=[],
+    noarchive=False,
+)
+pyz = PYZ(a.pure)
+
+exe = EXE(
+    pyz,
+    a.scripts,
+    a.binaries,
+    a.datas,
+    [],
+    name='transferwee',
+    debug=False,
+    bootloader_ignore_signals=False,
+    strip=False,
+    upx=True,
+    upx_exclude=[],
+    runtime_tmpdir=None,
+    console=True,
+    disable_windowed_traceback=False,
+    argv_emulation=False,
+    target_arch=None,
+    codesign_identity=None,
+    entitlements_file=None,
+)


### PR DESCRIPTION
Add GitHub Workflow to generate transferwee.exe in onefile mode. This will allow a more simple use on Windows than installing python, etc...