### PR TITLE
Add authenticated uploads with token caching

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,17 @@
-__pycache__
+# Python
+venv/
+__pycache__/
+*.pyc
+*.pyo
+
+# Node / Frontend
+node_modules/
+dsm/frontend/dist/
+dsm/frontend/package-lock.json
+
+# SPK build
+dsm/spk/_build/
+dsm/spk/*.spk
+
+# Test files
+hola

--- a/README.md
+++ b/README.md
@@ -102,7 +102,8 @@ to cache the tokens.
 ```
 % transferwee upload -h
 usage: transferwee upload [-h] [-n display_name] [-m message] [-f from]
-                          [-t to [to ...]] [-u email] [-v]
+                          [-t to [to ...]] [-u email] [--auth-file path]
+                          [--expire-in duration] [-v]
                           file [file ...]
 
 positional arguments:
@@ -116,6 +117,10 @@ optional arguments:
   -t to [to ...]        recipient emails
   -u email, --user email
                         WeTransfer account email (or WETRANSFER_USER env var)
+  --auth-file path      path to auth cache JSON file (overrides -u and default
+                        cache)
+  --expire-in duration  transfer expiration, e.g. 3600, 90m, 24h, 30d
+                        (default: 30d)
   -v                    get verbose/debug logging
 ```
 
@@ -144,6 +149,30 @@ Or using the environment variable:
 % export WETRANSFER_USER=user@example.com
 % transferwee upload hello
 https://we.tl/t-AbCdEfGhIj
+```
+
+#### Using an external auth cache file
+
+If you manage the auth cache outside the default `~/.config/transferwee/`
+directory (e.g. in a Docker container or a CI pipeline), you can point
+directly to a JSON cache file with `--auth-file`. This overrides both
+`-u` and `WETRANSFER_USER`:
+
+```
+% transferwee upload --auth-file /path/to/auth_cache.json hello
+https://we.tl/t-XyZwVuTsRq
+```
+
+#### Transfer expiration
+
+By default, link uploads expire after 30 days. Use `--expire-in` to set
+a custom duration. The value can be raw seconds or a human-readable
+shorthand (`s` seconds, `m` minutes, `h` hours, `d` days):
+
+```
+% transferwee upload --expire-in 7d hello          # expires in 7 days
+% transferwee upload --expire-in 12h hello         # expires in 12 hours
+% transferwee upload --expire-in 3600 hello        # expires in 1 hour
 ```
 
 ### Download file

--- a/README.md
+++ b/README.md
@@ -30,15 +30,17 @@ locally so that subsequent uploads can run without user interaction.
 
 ```
 % transferwee auth -h
-usage: transferwee auth [-h] [-l] [-v] [email]
+usage: transferwee auth [-h] [-l] [--client-id ID] [--audience URL] [-v] [email]
 
 positional arguments:
-  email       WeTransfer account email to authenticate
+  email           WeTransfer account email to authenticate
 
 optional arguments:
-  -h, --help  show this help message and exit
-  -l, --list  list cached accounts and token status
-  -v          get verbose/debug logging
+  -h, --help      show this help message and exit
+  -l, --list      list cached accounts and token status
+  --client-id ID  override Auth0 client_id (saved to oauth_config.json)
+  --audience URL  override Auth0 audience (saved to oauth_config.json)
+  -v              get verbose/debug logging
 ```
 
 The following example authenticates with WeTransfer. A verification code
@@ -64,6 +66,21 @@ check which accounts are cached:
 
 Multiple accounts are supported. Each account gets its own cache file
 under `~/.config/transferwee/`.
+
+### OAuth configuration
+
+The Auth0 `client_id` and `audience` values used for authentication are
+hardcoded with known-good defaults. If WeTransfer changes these values
+on their end, the `--client-id` and `--audience` flags on the `auth`
+subcommand allow overriding them without modifying the source code:
+
+```
+% transferwee auth --client-id NEW_ID --audience NEW_AUDIENCE user@example.com
+```
+
+The overrides are persisted to `~/.config/transferwee/oauth_config.json`
+and will be used for all subsequent auth and upload operations. If the
+config file does not exist, the built-in defaults are used.
 
 ### Upload files
 

--- a/README.md
+++ b/README.md
@@ -7,18 +7,63 @@ transferwee is a simple Python 3 script to download/upload files via
 
 ```
 % transferwee -h
-usage: transferwee [-h] {download,upload} ...
+usage: transferwee [-h] {download,auth,upload} ...
 
 Download/upload files via wetransfer.com
 
 positional arguments:
-  {download,upload}  action
-    download         download files
-    upload           upload files
+  {download,auth,upload}
+                        action
+    download            download files
+    auth                authenticate with WeTransfer (OTP via email)
+    upload              upload files
 
 optional arguments:
-  -h, --help         show this help message and exit
+  -h, --help            show this help message and exit
 ```
+
+### Authenticate
+
+`auth` subcommand authenticates with WeTransfer via a one-time
+verification code sent to your email. The resulting tokens are cached
+locally so that subsequent uploads can run without user interaction.
+
+```
+% transferwee auth -h
+usage: transferwee auth [-h] [-l] [-v] [email]
+
+positional arguments:
+  email       WeTransfer account email to authenticate
+
+optional arguments:
+  -h, --help  show this help message and exit
+  -l, --list  list cached accounts and token status
+  -v          get verbose/debug logging
+```
+
+The following example authenticates with WeTransfer. A verification code
+will be sent to the given email address:
+
+```
+% transferwee auth user@example.com
+Sending verification code to user@example.com
+Enter the verification code sent to your email: ABC123
+Authentication successful. Tokens cached to /home/user/.config/transferwee/auth_1a2b3c4d5e6f7890.json
+```
+
+Once authenticated, the cached refresh token is used automatically. To
+check which accounts are cached:
+
+```
+% transferwee auth -l
+  user@example.com
+    status: refresh_token cached
+    access_token valid until 2026-03-19 22:30 UTC, last refreshed 2026-03-19 21:30 UTC
+    file:   /home/user/.config/transferwee/auth_1a2b3c4d5e6f7890.json
+```
+
+Multiple accounts are supported. Each account gets its own cache file
+under `~/.config/transferwee/`.
 
 ### Upload files
 
@@ -32,20 +77,29 @@ also note that because `-t` option accepts several fields a `--`
 is needed to separate it with the file arguments).
 Otherwise the link upload will be used.
 
+When `-u` option is passed (or `WETRANSFER_USER` environment variable
+is set) the upload is performed as an authenticated user, which avoids
+the limits applied to anonymous transfers. Run `transferwee auth` first
+to cache the tokens.
+
 ```
 % transferwee upload -h
-usage: transferwee upload [-h] [-n display_name] [-m message] [-f from] [-t to [to ...]] [-v] file [file ...]
+usage: transferwee upload [-h] [-n display_name] [-m message] [-f from]
+                          [-t to [to ...]] [-u email] [-v]
+                          file [file ...]
 
 positional arguments:
-  file             files to upload
+  file                  files to upload
 
 optional arguments:
-  -h, --help       show this help message and exit
-  -n display_name  title for the transfer
-  -m message       message description for the transfer
-  -f from          sender email
-  -t to [to ...]   recipient emails
-  -v               get verbose/debug logging
+  -h, --help            show this help message and exit
+  -n display_name       title for the transfer
+  -m message            message description for the transfer
+  -f from               sender email
+  -t to [to ...]        recipient emails
+  -u email, --user email
+                        WeTransfer account email (or WETRANSFER_USER env var)
+  -v                    get verbose/debug logging
 ```
 
 The following example creates an `hello` text file with just `Hello world!` and
@@ -57,6 +111,22 @@ then upload it with the message passed via `-m` option:
 MD5 (hello) = 59ca0efa9f5633cb0371bbc0355478d8
 % transferwee upload -m 'Just a text file with the mandatory message...' hello
 https://we.tl/o8mGUXnxyZ
+```
+
+Authenticated upload example:
+
+```
+% transferwee auth user@example.com
+% transferwee upload -u user@example.com hello
+https://we.tl/t-AbCdEfGhIj
+```
+
+Or using the environment variable:
+
+```
+% export WETRANSFER_USER=user@example.com
+% transferwee upload hello
+https://we.tl/t-AbCdEfGhIj
 ```
 
 ### Download file

--- a/transferwee.py
+++ b/transferwee.py
@@ -582,10 +582,10 @@ def _storm_preflight_item(
     Return a dictionary with "blocks", "item_type" and "path" keys.
     """
     filename = _file_display_name(file, path_map)
-    filesize = os.path.getsize(file)
+    chunks = _file_chunks(file)
 
     return {
-        "blocks": [{"content_length": filesize}],
+        "blocks": [{"content_length": c["content_length"]} for c in chunks],
         "item_type": "file",
         "path": filename,
     }
@@ -620,6 +620,9 @@ def _storm_preflight(
     return r.json()
 
 
+STORM_MAX_BLOCK_SIZE = 15 * 1024 * 1024  # 15 MiB per WeTransfer limit
+
+
 def _md5(file: str) -> str:
     """Given a file, calculate its MD5 checksum.
 
@@ -632,23 +635,60 @@ def _md5(file: str) -> str:
     return h.hexdigest()
 
 
-def _storm_prepare_item(file: str) -> Dict[str, Union[int, str]]:
-    """Given a file, prepare the block for blocks dictionary.
+def _md5_chunk(file: str, offset: int, length: int) -> str:
+    """Given a file, offset and length, calculate MD5 of that chunk."""
+    h = hashlib.md5()
+    with open(file, "rb") as f:
+        f.seek(offset)
+        remaining = length
+        while remaining > 0:
+            data = f.read(min(4096, remaining))
+            if not data:
+                break
+            h.update(data)
+            remaining -= len(data)
+    return h.hexdigest()
 
-    Return a dictionary with "content_length" and "content_md5_hex" keys.
+
+def _file_chunks(file: str) -> List[Dict[str, Union[int, str]]]:
+    """Split a file into chunk descriptors for storm upload.
+
+    Each chunk has offset, content_length and content_md5_hex.
+    Files smaller than STORM_MAX_BLOCK_SIZE produce a single chunk.
     """
     filesize = os.path.getsize(file)
+    if filesize <= STORM_MAX_BLOCK_SIZE:
+        return [{"offset": 0, "content_length": filesize, "content_md5_hex": _md5(file)}]
+    chunks = []
+    offset = 0
+    while offset < filesize:
+        length = min(STORM_MAX_BLOCK_SIZE, filesize - offset)
+        chunks.append({
+            "offset": offset,
+            "content_length": length,
+            "content_md5_hex": _md5_chunk(file, offset, length),
+        })
+        offset += length
+    return chunks
 
-    return {"content_length": filesize, "content_md5_hex": _md5(file)}
 
-
-def _storm_prepare(authorization: str, filenames: List[str]) -> Dict[Any, Any]:
+def _storm_prepare(
+    authorization: str, filenames: List[str],
+) -> tuple:
     """Given an Authorization token and filenames prepare for block uploads.
 
-    Return the parsed JSON response.
+    Return (parsed JSON response, list of chunk lists per file).
     """
+    file_chunks = [_file_chunks(f) for f in filenames]
+    all_blocks = []
+    for chunks in file_chunks:
+        for chunk in chunks:
+            all_blocks.append({
+                "content_length": chunk["content_length"],
+                "content_md5_hex": chunk["content_md5_hex"],
+            })
     j = {
-        "blocks": [_storm_prepare_item(f) for f in filenames],
+        "blocks": all_blocks,
     }
     requests.options(
         _storm_urls(authorization)["WETRANSFER_STORM_BLOCK"],
@@ -672,44 +712,39 @@ def _storm_prepare(authorization: str, filenames: List[str]) -> Dict[Any, Any]:
     if not resp.get("ok", True) or "data" not in resp:
         err_msg = resp.get("error", {}).get("message", str(resp))
         raise Exception(f"Storm prepare failed: {err_msg}")
-    return resp
+    return resp, file_chunks
 
 
 def _storm_finalize_item(
-    file: str, block_id: str, path_map: Dict[str, str] = {},
+    file: str, block_ids: List[str], path_map: Dict[str, str] = {},
 ) -> Dict[str, Union[List[str], str]]:
-    """Given a file and block_id prepare the item block dictionary.
+    """Given a file and its block_ids prepare the item block dictionary.
 
     Return a dictionary with "block_ids", "item_type" and "path" keys.
-
-    XXX: Is it possible to actually have more than one block?
-    XXX: If yes this - and probably other parts of the code involved with
-    XXX: blocks - needs to be instructed to handle them instead of
-    XXX: assuming that one file is associated with one block.
     """
     filename = _file_display_name(file, path_map)
 
     return {
-        "block_ids": [
-            block_id,
-        ],
+        "block_ids": block_ids,
         "item_type": "file",
         "path": filename,
     }
 
 
 def _storm_finalize(
-    authorization: str, filenames: List[str], block_ids: List[str],
+    authorization: str, filenames: List[str],
+    file_block_ids: List[List[str]],
     path_map: Dict[str, str] = {},
 ) -> Dict[Any, Any]:
     """Given an Authorization token, filenames and block ids finalize upload.
 
+    file_block_ids is a list of lists: one list of block_ids per file.
     Return the parsed JSON response.
     """
     j = {
         "items": [
-            _storm_finalize_item(f, bid, path_map)
-            for f, bid in zip(filenames, block_ids)
+            _storm_finalize_item(f, bids, path_map)
+            for f, bids in zip(filenames, file_block_ids)
         ],
     }
     requests.options(
@@ -747,11 +782,18 @@ def _storm_finalize(
     return r.json()
 
 
-def _storm_upload(url: str, file: str) -> None:
-    """Given an url and file upload it.
+def _storm_upload(
+    url: str, file: str,
+    offset: int = 0, length: int = 0, md5_hex: str = "",
+) -> None:
+    """Given an url and file (or chunk) upload it.
 
-    Does not return anything.
+    When offset/length/md5_hex are provided, only that portion is uploaded.
+    Otherwise the entire file is uploaded.
     """
+    if not md5_hex:
+        md5_hex = _md5(file)
+        length = os.path.getsize(file)
     requests.options(
         url,
         headers={
@@ -761,13 +803,15 @@ def _storm_upload(url: str, file: str) -> None:
         },
     )
     with open(file, "rb") as f:
+        f.seek(offset)
+        data = f.read(length)
         requests.put(
             url,
-            data=f,
+            data=data,
             headers={
                 "Origin": "https://wetransfer.com",
                 "Content-MD5": binascii.b2a_base64(
-                    binascii.unhexlify(_md5(file)), newline=False
+                    binascii.unhexlify(md5_hex), newline=False
                 ),
                 "X-Uploader": "storm",
                 "User-Agent": WETRANSFER_USER_AGENT,
@@ -1016,15 +1060,30 @@ def upload(
     logger.debug("Doing preflight storm")
     _storm_preflight(transfer["storm_upload_token"], files, path_map)
     logger.debug("Preparing storm block upload")
-    blocks = _storm_prepare(transfer["storm_upload_token"], files)
-    for f, b in zip(files, blocks["data"]["blocks"]):
-        logger.debug(f"Uploading file {f}")
-        _storm_upload(b["presigned_put_url"], f)
+    resp, file_chunks = _storm_prepare(transfer["storm_upload_token"], files)
+    api_blocks = resp["data"]["blocks"]
+    block_idx = 0
+    file_block_ids = []
+    for f, chunks in zip(files, file_chunks):
+        block_ids = []
+        for chunk in chunks:
+            b = api_blocks[block_idx]
+            logger.debug(
+                f"Uploading {f} chunk offset={chunk['offset']} "
+                f"size={chunk['content_length']}"
+            )
+            _storm_upload(
+                b["presigned_put_url"], f,
+                chunk["offset"], chunk["content_length"], chunk["content_md5_hex"],
+            )
+            block_ids.append(b["block_id"])
+            block_idx += 1
+        file_block_ids.append(block_ids)
     logger.debug("Finalizing storm batch upload")
     _storm_finalize(
         transfer["storm_upload_token"],
         files,
-        [b["block_id"] for b in blocks["data"]["blocks"]],
+        file_block_ids,
         path_map,
     )
     logger.debug(f"Finalizing upload with transfer id {transfer['id']}")

--- a/transferwee.py
+++ b/transferwee.py
@@ -38,6 +38,9 @@ files from a `we.tl' or `wetransfer.com/downloads' URLs and upload files that
 will be shared via emails or link.
 """
 
+import random
+import string
+import uuid
 from typing import Any, Dict, List, Optional, Union
 import binascii
 import functools
@@ -53,9 +56,8 @@ import requests
 
 WETRANSFER_API_URL = "https://wetransfer.com/api/v4/transfers"
 WETRANSFER_DOWNLOAD_URL = WETRANSFER_API_URL + "/{transfer_id}/download"
-WETRANSFER_UPLOAD_EMAIL_URL = WETRANSFER_API_URL + "/email"
+WETRANSFER_UPLOAD_URL = WETRANSFER_API_URL + "/{transfer_id}/passwordless"
 WETRANSFER_VERIFY_URL = WETRANSFER_API_URL + "/{transfer_id}/verify"
-WETRANSFER_UPLOAD_LINK_URL = WETRANSFER_API_URL + "/link"
 WETRANSFER_FINALIZE_URL = WETRANSFER_API_URL + "/{transfer_id}/finalize"
 
 WETRANSFER_EXPIRE_IN = 604800
@@ -176,12 +178,7 @@ def _file_name_and_size(file: str) -> Dict[str, Union[int, str]]:
 
 
 def _prepare_session() -> Optional[requests.Session]:
-    """Prepare a wetransfer.com session.
-
-    Return a requests session that will always pass the required headers
-    and with cookies properly populated that can be used for wetransfer
-    requests.
-    """
+    """Prepare a wetransfer.com session."""
     s = requests.Session()
     s.headers.update(
         {
@@ -189,14 +186,6 @@ def _prepare_session() -> Optional[requests.Session]:
             "x-requested-with": "XMLHttpRequest",
         }
     )
-    r = s.get("https://wetransfer.com/")
-    m = re.search('name="csrf-token" content="([^"]+)"', r.text)
-    if m:
-        logger.debug(f"Setting x-csrf-token header to {m.group(1)}")
-        s.headers.update({"x-csrf-token": m.group(1)})
-    else:
-        logger.debug("Could not find any csrf-token")
-
     return s
 
 
@@ -206,6 +195,10 @@ def _close_session(s: requests.Session) -> None:
     Terminate wetransfer.com session.
     """
     s.close()
+
+
+def generate_random_uuid():
+    return str(uuid.uuid4())
 
 
 def _prepare_email_upload(
@@ -221,37 +214,83 @@ def _prepare_email_upload(
 
     Return the parsed JSON response.
     """
+    lsid = generate_random_uuid()
+
     j = {
+        "downloader_email_verification": "anonymous",
         "files": [_file_name_and_size(f) for f in filenames],
         "from": sender,
+        "lsid": lsid,
         "display_name": display_name,
         "message": message,
         "recipients": recipients,
         "ui_language": "en",
     }
 
-    r = session.post(WETRANSFER_UPLOAD_EMAIL_URL, json=j)
-    return r.json()
+    r = session.post(WETRANSFER_API_URL, json=j)
+    r.raise_for_status()
+
+    return {"sender": sender, "id": r.json()["id"], "lsid": lsid}
+
+
+def generate_client_id():
+    """Generates a random client_id: 32 characters of letters and digits."""
+    characters = string.ascii_letters + string.digits
+    return "".join(random.choice(characters) for _ in range(32))
 
 
 def _verify_email_upload(
-    transfer_id: str, session: requests.Session
+    transfer_data: dict, session: requests.Session
 ) -> Dict[Any, Any]:
-    """Given a transfer_id, read the code from standard input.
+    """Given transfer_data, trigger passwordless login and verify via OTP.
 
     Return the parsed JSON response.
     """
-    code = input("Code:")
+    logger.debug("send code to sender email")
+    c_id = generate_client_id()
+    data = {"client_id": c_id, "email": transfer_data["sender"]}
+    url = "https://wetransfer.com/adroit/api/v1/login/passwordless"
+    response = requests.post(url, json=data)
+    response.raise_for_status()
 
-    j = {
-        "code": code,
-        "expire_in": WETRANSFER_EXPIRE_IN,
+    code = input("Confirmation code sent to your email:")
+
+    headers = {
+        "user-agent": WETRANSFER_USER_AGENT,
+        "x-csrf-token": "csrf-token",
     }
 
-    r = session.post(
-        WETRANSFER_VERIFY_URL.format(transfer_id=transfer_id), json=j
+    logger.debug("get access_token")
+    data = {
+        "grant_type": "http://auth0.com/oauth/grant-type/passwordless/otp",
+        "client_id": c_id,
+        "otp": code,
+        "realm": "email",
+        "username": transfer_data["sender"],
+    }
+    url = "https://auth.wetransfer.com/oauth/token"
+    response = requests.post(url, headers=headers, json=data)
+    response.raise_for_status()
+    tk = response.json()["access_token"]
+
+    logger.debug("Confirm upload")
+    headers = {
+        "authorization": f"Bearer {tk}",
+        "user-agent": WETRANSFER_USER_AGENT,
+    }
+    payload = {
+        "expire_in": 259200,
+        "lsid": transfer_data["lsid"],
+        "segment_id": "grace_period",
+    }
+    response = requests.post(
+        WETRANSFER_UPLOAD_URL.format(transfer_id=transfer_data["id"]),
+        headers=headers,
+        json=payload,
     )
-    return r.json()
+    response.raise_for_status()
+
+    return response.json()
 
 
 def _prepare_link_upload(
@@ -265,13 +304,15 @@ def _prepare_link_upload(
     Return the parsed JSON response.
     """
     j = {
+        "anonymous_transfer": True,
         "files": [_file_name_and_size(f) for f in filenames],
         "display_name": display_name,
         "message": message,
         "ui_language": "en",
     }
 
-    r = session.post(WETRANSFER_UPLOAD_LINK_URL, json=j)
+    r = session.post(WETRANSFER_API_URL, json=j)
+    r.raise_for_status()
     return r.json()
 
 
@@ -555,7 +596,7 @@ def upload(
         transfer = _prepare_email_upload(
             files, display_name, message, sender, recipients, s
         )
-        transfer = _verify_email_upload(transfer["id"], s)
+        transfer = _verify_email_upload(transfer, s)
     else:
         # link upload
         transfer = _prepare_link_upload(files, display_name, message, s)

--- a/transferwee.py
+++ b/transferwee.py
@@ -43,6 +43,7 @@ import string
 import uuid
 from typing import Any, Dict, List, Optional, Union
 import binascii
+import datetime
 import functools
 import hashlib
 import json
@@ -61,7 +62,23 @@ WETRANSFER_UPLOAD_URL = WETRANSFER_API_URL + "/{transfer_id}/passwordless"
 WETRANSFER_VERIFY_URL = WETRANSFER_API_URL + "/{transfer_id}/verify"
 WETRANSFER_FINALIZE_URL = WETRANSFER_API_URL + "/{transfer_id}/finalize"
 
-WETRANSFER_EXPIRE_IN = 604800
+WETRANSFER_EXPIRE_IN = 2592000  # 30 days
+
+
+_DURATION_KWARGS = {"s": "seconds", "m": "minutes", "h": "hours", "d": "days"}
+
+
+def _parse_duration(value: str) -> int:
+    """Parse a duration string like '30d', '24h', '90m', '3600' into seconds."""
+    m = re.fullmatch(r"(\d+)\s*(s|m|h|d)?", value.strip().lower())
+    if not m:
+        raise ValueError(f"Invalid duration: {value!r}")
+    amount = int(m.group(1))
+    unit = m.group(2) or "s"
+    td = datetime.timedelta(**{_DURATION_KWARGS[unit]: amount})
+    return int(td.total_seconds())
+
+
 WETRANSFER_USER_AGENT = "Mozilla/5.0 (Windows NT 10.0; Win64; x64; rv:102.0) Gecko/20100101 Firefox/102.0"
 
 WETRANSFER_AUTH0_URL = "https://auth.wetransfer.com/oauth/token"
@@ -512,6 +529,7 @@ def _prepare_link_upload(
     session: requests.Session,
     authenticated: bool = False,
     path_map: Dict[str, str] = {},
+    expire_in: int = WETRANSFER_EXPIRE_IN,
 ) -> Dict[Any, Any]:
     """Given a list of filenames and a message prepare for the link upload.
 
@@ -525,6 +543,7 @@ def _prepare_link_upload(
         "display_name": display_name,
         "message": message,
         "ui_language": "en",
+        "expire_in": expire_in,
     }
     if not authenticated:
         j["anonymous_transfer"] = True
@@ -776,7 +795,6 @@ def _finalize_upload(
 def auth_list() -> None:
     """List all cached WeTransfer accounts and their token status."""
     import glob
-    import datetime
 
     pattern = os.path.join(WETRANSFER_AUTH_CACHE_DIR, "auth_*.json")
     cache_files = glob.glob(pattern)
@@ -877,6 +895,7 @@ def upload(
     recipients: Optional[List[str]] = [],
     user: Optional[str] = None,
     auth_file: Optional[str] = None,
+    expire_in: int = WETRANSFER_EXPIRE_IN,
 ) -> str:
     """Given a list of files upload them and return the corresponding URL.
 
@@ -972,6 +991,7 @@ def upload(
             files, display_name, message, s,
             authenticated=auth_token is not None,
             path_map=path_map,
+            expire_in=expire_in,
         )
 
     logger.debug(
@@ -1121,6 +1141,13 @@ if __name__ == "__main__":
         help="path to auth cache JSON file (overrides -u and default cache)",
     )
     up.add_argument(
+        "--expire-in",
+        type=str,
+        default="30d",
+        metavar="duration",
+        help="transfer expiration, e.g. 3600, 90m, 24h, 30d (default: 30d)",
+    )
+    up.add_argument(
         "-v", action="store_true", help="get verbose/debug logging"
     )
     up.add_argument(
@@ -1156,6 +1183,7 @@ if __name__ == "__main__":
                 args.files, args.n, args.m, args.f, args.t,
                 args.user,
                 args.auth_file,
+                _parse_duration(args.expire_in),
             )
         )
         exit(0)

--- a/transferwee.py
+++ b/transferwee.py
@@ -207,12 +207,19 @@ def download(url: str, file: str = "") -> None:
             f.write(chunk)
 
 
-def _file_name_and_size(file: str) -> Dict[str, Union[int, str]]:
+def _file_display_name(file: str, path_map: Dict[str, str] = {}) -> str:
+    """Return the display name for a file (relative path or basename)."""
+    return path_map.get(file, os.path.basename(file))
+
+
+def _file_name_and_size(
+    file: str, path_map: Dict[str, str] = {}
+) -> Dict[str, Union[int, str]]:
     """Given a file, prepare the "item_type", "name" and "size" dictionary.
 
     Return a dictionary with "item_type", "name" and "size" keys.
     """
-    filename = os.path.basename(file)
+    filename = _file_display_name(file, path_map)
     filesize = os.path.getsize(file)
 
     return {"item_type": "file", "name": filename, "size": filesize}
@@ -249,6 +256,7 @@ def _prepare_email_upload(
     sender: str,
     recipients: List[str],
     session: requests.Session,
+    path_map: Dict[str, str] = {},
 ) -> Dict[Any, Any]:
     """Given a list of filenames, message a sender and recipients prepare for
     the email upload.
@@ -259,7 +267,7 @@ def _prepare_email_upload(
 
     j = {
         "downloader_email_verification": "anonymous",
-        "files": [_file_name_and_size(f) for f in filenames],
+        "files": [_file_name_and_size(f, path_map) for f in filenames],
         "from": sender,
         "lsid": lsid,
         "display_name": display_name,
@@ -503,6 +511,7 @@ def _prepare_link_upload(
     message: str,
     session: requests.Session,
     authenticated: bool = False,
+    path_map: Dict[str, str] = {},
 ) -> Dict[Any, Any]:
     """Given a list of filenames and a message prepare for the link upload.
 
@@ -512,7 +521,7 @@ def _prepare_link_upload(
     Return the parsed JSON response.
     """
     j = {
-        "files": [_file_name_and_size(f) for f in filenames],
+        "files": [_file_name_and_size(f, path_map) for f in filenames],
         "display_name": display_name,
         "message": message,
         "ui_language": "en",
@@ -547,13 +556,13 @@ def _storm_urls(
 
 
 def _storm_preflight_item(
-    file: str,
+    file: str, path_map: Dict[str, str] = {},
 ) -> Dict[str, Union[List[Dict[str, int]], str]]:
     """Given a file, prepare the item block dictionary.
 
     Return a dictionary with "blocks", "item_type" and "path" keys.
     """
-    filename = os.path.basename(file)
+    filename = _file_display_name(file, path_map)
     filesize = os.path.getsize(file)
 
     return {
@@ -564,14 +573,14 @@ def _storm_preflight_item(
 
 
 def _storm_preflight(
-    authorization: str, filenames: List[str]
+    authorization: str, filenames: List[str], path_map: Dict[str, str] = {},
 ) -> Dict[Any, Any]:
     """Given an Authorization token and filenames do preflight for upload.
 
     Return the parsed JSON response.
     """
     j = {
-        "items": [_storm_preflight_item(f) for f in filenames],
+        "items": [_storm_preflight_item(f, path_map) for f in filenames],
     }
     requests.options(
         _storm_urls(authorization)["WETRANSFER_STORM_PREFLIGHT"],
@@ -648,7 +657,7 @@ def _storm_prepare(authorization: str, filenames: List[str]) -> Dict[Any, Any]:
 
 
 def _storm_finalize_item(
-    file: str, block_id: str
+    file: str, block_id: str, path_map: Dict[str, str] = {},
 ) -> Dict[str, Union[List[str], str]]:
     """Given a file and block_id prepare the item block dictionary.
 
@@ -659,7 +668,7 @@ def _storm_finalize_item(
     XXX: blocks - needs to be instructed to handle them instead of
     XXX: assuming that one file is associated with one block.
     """
-    filename = os.path.basename(file)
+    filename = _file_display_name(file, path_map)
 
     return {
         "block_ids": [
@@ -671,7 +680,8 @@ def _storm_finalize_item(
 
 
 def _storm_finalize(
-    authorization: str, filenames: List[str], block_ids: List[str]
+    authorization: str, filenames: List[str], block_ids: List[str],
+    path_map: Dict[str, str] = {},
 ) -> Dict[Any, Any]:
     """Given an Authorization token, filenames and block ids finalize upload.
 
@@ -679,7 +689,7 @@ def _storm_finalize(
     """
     j = {
         "items": [
-            _storm_finalize_item(f, bid)
+            _storm_finalize_item(f, bid, path_map)
             for f, bid in zip(filenames, block_ids)
         ],
     }
@@ -890,17 +900,40 @@ def upload(
     Return the short URL of the transfer on success.
     """
 
-    # Check that all files exists
-    logger.debug("Checking that all files exists")
+    # Expand directories recursively and build a path map that preserves
+    # relative folder structure (e.g. "hello/hello-1.txt") so that
+    # WeTransfer recreates the directory tree on download.
+    expanded: List[str] = []
+    path_map: Dict[str, str] = {}
     for f in files:
-        if not os.path.exists(f):
+        if os.path.isdir(f):
+            base_dir = f
+            for root, _dirs, fnames in os.walk(f):
+                for name in sorted(fnames):
+                    full = os.path.join(root, name)
+                    if os.path.getsize(full) == 0:
+                        logger.debug(f"Skipping empty file: {full}")
+                        continue
+                    rel = os.path.relpath(full, os.path.dirname(base_dir))
+                    expanded.append(full)
+                    path_map[full] = rel
+        elif os.path.exists(f):
+            if os.path.getsize(f) == 0:
+                logger.debug(f"Skipping empty file: {f}")
+                continue
+            expanded.append(f)
+        else:
             raise FileNotFoundError(f)
+    files = expanded
 
-    # Check that there are no duplicates filenames
-    # (despite possible different dirname())
-    logger.debug("Checking for no duplicate filenames")
-    filenames = [os.path.basename(f) for f in files]
-    if len(files) != len(set(filenames)):
+    if not files:
+        raise FileNotFoundError("No files to upload")
+
+    logger.debug(f"Uploading {len(files)} file(s)")
+
+    # Check that there are no duplicate display paths
+    display_names = [_file_display_name(f, path_map) for f in files]
+    if len(files) != len(set(display_names)):
         raise FileExistsError("Duplicate filenames")
 
     # Authenticate if credentials were provided
@@ -930,7 +963,7 @@ def upload(
     if sender and recipients:
         # email upload
         transfer = _prepare_email_upload(
-            files, display_name, message, sender, recipients, s
+            files, display_name, message, sender, recipients, s, path_map,
         )
         transfer = _verify_email_upload(transfer, s)
     else:
@@ -938,6 +971,7 @@ def upload(
         transfer = _prepare_link_upload(
             files, display_name, message, s,
             authenticated=auth_token is not None,
+            path_map=path_map,
         )
 
     logger.debug(
@@ -960,7 +994,7 @@ def upload(
     )
     logger.debug(f"Get transfer id {transfer['id']}")
     logger.debug("Doing preflight storm")
-    _storm_preflight(transfer["storm_upload_token"], files)
+    _storm_preflight(transfer["storm_upload_token"], files, path_map)
     logger.debug("Preparing storm block upload")
     blocks = _storm_prepare(transfer["storm_upload_token"], files)
     for f, b in zip(files, blocks["data"]["blocks"]):
@@ -971,6 +1005,7 @@ def upload(
         transfer["storm_upload_token"],
         files,
         [b["block_id"] for b in blocks["data"]["blocks"]],
+        path_map,
     )
     logger.debug(f"Finalizing upload with transfer id {transfer['id']}")
     shortened_url = _finalize_upload(transfer["id"], s)["shortened_url"]

--- a/transferwee.py
+++ b/transferwee.py
@@ -350,12 +350,13 @@ def _save_auth_cache(
     email: str,
     access_token: str,
     refresh_token: Optional[str],
+    auth_file: Optional[str] = None,
 ) -> None:
     """Persist auth tokens to disk for later reuse."""
     if not refresh_token:
         return
-    cache_file = _auth_cache_path(email)
-    os.makedirs(WETRANSFER_AUTH_CACHE_DIR, mode=0o700, exist_ok=True)
+    cache_file = auth_file or _auth_cache_path(email)
+    os.makedirs(os.path.dirname(cache_file) or ".", mode=0o700, exist_ok=True)
     payload = {
         "email": email,
         "access_token": access_token,
@@ -367,12 +368,12 @@ def _save_auth_cache(
     logger.debug(f"Auth tokens cached to {cache_file}")
 
 
-def _load_cached_auth(email: str) -> Optional[str]:
+def _load_cached_auth(email: str, auth_file: Optional[str] = None) -> Optional[str]:
     """Try to obtain a fresh access_token using a cached refresh_token.
 
     Return access_token on success, None otherwise.
     """
-    cache_file = _auth_cache_path(email)
+    cache_file = auth_file or _auth_cache_path(email)
     if not os.path.exists(cache_file):
         logger.debug("No auth cache found")
         return None
@@ -413,7 +414,7 @@ def _load_cached_auth(email: str) -> Optional[str]:
     new_access = token_data.get("access_token")
     new_refresh = token_data.get("refresh_token", refresh_token)
     if new_access:
-        _save_auth_cache(email, new_access, new_refresh)
+        _save_auth_cache(email, new_access, new_refresh, auth_file)
         logger.debug("Token refresh successful")
         return new_access
 
@@ -470,16 +471,18 @@ def _authenticate_otp(email: str) -> Dict[str, str]:
     return result
 
 
-def _authenticate(email: str) -> str:
+def _authenticate(email: str, auth_file: Optional[str] = None) -> str:
     """Authenticate with WeTransfer.
 
     Tries cached refresh_token first (no user interaction needed).
     Falls back to passwordless OTP if no cache or refresh fails.
     Caches tokens after successful OTP for future runs.
 
+    When auth_file is provided it overrides the default cache path.
+
     Return access_token.
     """
-    token = _load_cached_auth(email)
+    token = _load_cached_auth(email, auth_file)
     if token:
         return token
 
@@ -489,6 +492,7 @@ def _authenticate(email: str) -> str:
         email,
         otp_result["access_token"],
         otp_result.get("refresh_token"),
+        auth_file,
     )
     return otp_result["access_token"]
 
@@ -635,7 +639,12 @@ def _storm_prepare(authorization: str, filenames: List[str]) -> Dict[Any, Any]:
             "User-Agent": WETRANSFER_USER_AGENT,
         },
     )
-    return r.json()
+    resp = r.json()
+    logger.debug(f"_storm_prepare response ({r.status_code}): {resp}")
+    if not resp.get("ok", True) or "data" not in resp:
+        err_msg = resp.get("error", {}).get("message", str(resp))
+        raise Exception(f"Storm prepare failed: {err_msg}")
+    return resp
 
 
 def _storm_finalize_item(
@@ -857,6 +866,7 @@ def upload(
     sender: Optional[str] = None,
     recipients: Optional[List[str]] = [],
     user: Optional[str] = None,
+    auth_file: Optional[str] = None,
 ) -> str:
     """Given a list of files upload them and return the corresponding URL.
 
@@ -895,7 +905,15 @@ def upload(
 
     # Authenticate if credentials were provided
     auth_token = None
-    if user:
+    if auth_file:
+        logger.debug(f"Authenticating from auth file: {auth_file}")
+        auth_token = _load_cached_auth("", auth_file)
+        if not auth_token:
+            raise ConnectionError(
+                f"Could not authenticate from {auth_file}. "
+                "The refresh token may have expired."
+            )
+    elif user:
         logger.debug(f"Authenticating as {user}")
         auth_token = _authenticate(user)
         logger.debug("Authentication successful")
@@ -1062,6 +1080,12 @@ if __name__ == "__main__":
         help="WeTransfer account email (or WETRANSFER_USER env var)",
     )
     up.add_argument(
+        "--auth-file",
+        type=str,
+        metavar="path",
+        help="path to auth cache JSON file (overrides -u and default cache)",
+    )
+    up.add_argument(
         "-v", action="store_true", help="get verbose/debug logging"
     )
     up.add_argument(
@@ -1096,6 +1120,7 @@ if __name__ == "__main__":
             upload(
                 args.files, args.n, args.m, args.f, args.t,
                 args.user,
+                args.auth_file,
             )
         )
         exit(0)

--- a/transferwee.py
+++ b/transferwee.py
@@ -68,8 +68,44 @@ WETRANSFER_AUTH0_URL = "https://auth.wetransfer.com/oauth/token"
 WETRANSFER_AUTH0_CLIENT_ID = "dXWFQjiW1jxWCFG0hOVpqrk4h9vGeanc"
 WETRANSFER_AUTH0_AUDIENCE = "aud://transfer-api-prod.wetransfer/"
 
+WETRANSFER_OAUTH_CONFIG = os.path.join(
+    os.environ.get("XDG_CONFIG_HOME", os.path.expanduser("~/.config")),
+    "transferwee",
+    "oauth_config.json",
+)
+
 
 logger = logging.getLogger(__name__)
+
+
+def _load_oauth_config() -> Dict[str, str]:
+    """Load OAuth config from disk, falling back to hardcoded defaults."""
+    config = {
+        "client_id": WETRANSFER_AUTH0_CLIENT_ID,
+        "audience": WETRANSFER_AUTH0_AUDIENCE,
+    }
+    if os.path.exists(WETRANSFER_OAUTH_CONFIG):
+        try:
+            with open(WETRANSFER_OAUTH_CONFIG, "r") as f:
+                stored = json.load(f)
+            config.update(
+                {k: v for k, v in stored.items() if k in config and v}
+            )
+            logger.debug(f"OAuth config loaded from {WETRANSFER_OAUTH_CONFIG}")
+        except (json.JSONDecodeError, OSError) as e:
+            logger.debug(f"Could not read OAuth config: {e}")
+    return config
+
+
+def _save_oauth_config(client_id: str, audience: str) -> None:
+    """Persist OAuth config overrides to disk."""
+    config_dir = os.path.dirname(WETRANSFER_OAUTH_CONFIG)
+    os.makedirs(config_dir, mode=0o700, exist_ok=True)
+    payload = {"client_id": client_id, "audience": audience}
+    with open(WETRANSFER_OAUTH_CONFIG, "w") as f:
+        json.dump(payload, f, indent=2)
+    os.chmod(WETRANSFER_OAUTH_CONFIG, 0o600)
+    logger.debug(f"OAuth config saved to {WETRANSFER_OAUTH_CONFIG}")
 
 
 def download_url(url: str) -> Optional[str]:
@@ -354,10 +390,11 @@ def _load_cached_auth(email: str) -> Optional[str]:
         return None
 
     logger.debug("Attempting token refresh")
+    oauth_cfg = _load_oauth_config()
     data = {
         "grant_type": "refresh_token",
-        "client_id": WETRANSFER_AUTH0_CLIENT_ID,
-        "audience": WETRANSFER_AUTH0_AUDIENCE,
+        "client_id": oauth_cfg["client_id"],
+        "audience": oauth_cfg["audience"],
         "refresh_token": refresh_token,
     }
     r = requests.post(
@@ -391,8 +428,10 @@ def _authenticate_otp(email: str) -> Dict[str, str]:
 
     Return dict with "access_token" and optionally "refresh_token".
     """
+    oauth_cfg = _load_oauth_config()
+
     logger.debug(f"Requesting OTP code for {email}")
-    data = {"client_id": WETRANSFER_AUTH0_CLIENT_ID, "email": email}
+    data = {"client_id": oauth_cfg["client_id"], "email": email}
     r = requests.post(
         "https://wetransfer.com/adroit/api/v1/login/passwordless",
         json=data,
@@ -404,8 +443,8 @@ def _authenticate_otp(email: str) -> Dict[str, str]:
     logger.debug("Exchanging OTP for access_token")
     data = {
         "grant_type": "http://auth0.com/oauth/grant-type/passwordless/otp",
-        "client_id": WETRANSFER_AUTH0_CLIENT_ID,
-        "audience": WETRANSFER_AUTH0_AUDIENCE,
+        "client_id": oauth_cfg["client_id"],
+        "audience": oauth_cfg["audience"],
         "otp": code,
         "realm": "email",
         "username": email,
@@ -764,14 +803,29 @@ def auth_list() -> None:
         print()
 
 
-def auth(email: str) -> None:
+def auth(
+    email: str,
+    client_id: Optional[str] = None,
+    audience: Optional[str] = None,
+) -> None:
     """Authenticate with WeTransfer and cache tokens for future use.
 
     Triggers the OTP flow (a verification code is sent to the given
     email) and stores the resulting tokens in the local cache.
     Subsequent upload calls with the same email will use the cached
     refresh_token without requiring user interaction.
+
+    If client_id or audience are provided they are persisted to
+    oauth_config.json and used for this and all future auth flows.
     """
+    if client_id or audience:
+        current = _load_oauth_config()
+        _save_oauth_config(
+            client_id or current["client_id"],
+            audience or current["audience"],
+        )
+        logger.info(f"OAuth config saved to {WETRANSFER_OAUTH_CONFIG}")
+
     cached = _load_cached_auth(email)
     if cached:
         logger.info(f"Already authenticated as {email} (token refreshed)")
@@ -964,6 +1018,18 @@ if __name__ == "__main__":
         help="list cached accounts and token status",
     )
     authp.add_argument(
+        "--client-id",
+        type=str,
+        metavar="ID",
+        help="override Auth0 client_id (saved to oauth_config.json)",
+    )
+    authp.add_argument(
+        "--audience",
+        type=str,
+        metavar="URL",
+        help="override Auth0 audience (saved to oauth_config.json)",
+    )
+    authp.add_argument(
         "-v", action="store_true", help="get verbose/debug logging"
     )
 
@@ -1011,7 +1077,7 @@ if __name__ == "__main__":
         if args.list:
             auth_list()
         elif args.email:
-            auth(args.email)
+            auth(args.email, args.client_id, args.audience)
         else:
             authp.print_help()
         exit(0)

--- a/transferwee.py
+++ b/transferwee.py
@@ -47,6 +47,7 @@ import functools
 import hashlib
 import json
 import logging
+import os
 import os.path
 import re
 import time
@@ -62,6 +63,10 @@ WETRANSFER_FINALIZE_URL = WETRANSFER_API_URL + "/{transfer_id}/finalize"
 
 WETRANSFER_EXPIRE_IN = 604800
 WETRANSFER_USER_AGENT = "Mozilla/5.0 (Windows NT 10.0; Win64; x64; rv:102.0) Gecko/20100101 Firefox/102.0"
+
+WETRANSFER_AUTH0_URL = "https://auth.wetransfer.com/oauth/token"
+WETRANSFER_AUTH0_CLIENT_ID = "dXWFQjiW1jxWCFG0hOVpqrk4h9vGeanc"
+WETRANSFER_AUTH0_AUDIENCE = "aud://transfer-api-prod.wetransfer/"
 
 
 logger = logging.getLogger(__name__)
@@ -293,23 +298,184 @@ def _verify_email_upload(
     return response.json()
 
 
+WETRANSFER_AUTH_CACHE_DIR = os.path.join(
+    os.environ.get("XDG_CONFIG_HOME", os.path.expanduser("~/.config")),
+    "transferwee",
+)
+
+
+def _auth_cache_path(email: str) -> str:
+    """Return the cache file path for a given email."""
+    email_hash = hashlib.sha256(email.lower().encode()).hexdigest()[:16]
+    return os.path.join(WETRANSFER_AUTH_CACHE_DIR, f"auth_{email_hash}.json")
+
+
+def _save_auth_cache(
+    email: str,
+    access_token: str,
+    refresh_token: Optional[str],
+) -> None:
+    """Persist auth tokens to disk for later reuse."""
+    if not refresh_token:
+        return
+    cache_file = _auth_cache_path(email)
+    os.makedirs(WETRANSFER_AUTH_CACHE_DIR, mode=0o700, exist_ok=True)
+    payload = {
+        "email": email,
+        "access_token": access_token,
+        "refresh_token": refresh_token,
+    }
+    with open(cache_file, "w") as f:
+        json.dump(payload, f)
+    os.chmod(cache_file, 0o600)
+    logger.debug(f"Auth tokens cached to {cache_file}")
+
+
+def _load_cached_auth(email: str) -> Optional[str]:
+    """Try to obtain a fresh access_token using a cached refresh_token.
+
+    Return access_token on success, None otherwise.
+    """
+    cache_file = _auth_cache_path(email)
+    if not os.path.exists(cache_file):
+        logger.debug("No auth cache found")
+        return None
+
+    try:
+        with open(cache_file, "r") as f:
+            cache = json.load(f)
+    except (json.JSONDecodeError, OSError) as e:
+        logger.debug(f"Could not read auth cache: {e}")
+        return None
+
+    refresh_token = cache.get("refresh_token")
+    if not refresh_token:
+        logger.debug("No refresh_token in cache")
+        return None
+
+    logger.debug("Attempting token refresh")
+    data = {
+        "grant_type": "refresh_token",
+        "client_id": WETRANSFER_AUTH0_CLIENT_ID,
+        "audience": WETRANSFER_AUTH0_AUDIENCE,
+        "refresh_token": refresh_token,
+    }
+    r = requests.post(
+        WETRANSFER_AUTH0_URL,
+        headers={
+            "User-Agent": WETRANSFER_USER_AGENT,
+            "Content-Type": "application/json",
+        },
+        json=data,
+    )
+    if r.status_code != 200:
+        logger.debug(f"Token refresh failed ({r.status_code}): {r.text[:200]}")
+        return None
+
+    token_data = r.json()
+    new_access = token_data.get("access_token")
+    new_refresh = token_data.get("refresh_token", refresh_token)
+    if new_access:
+        _save_auth_cache(email, new_access, new_refresh)
+        logger.debug("Token refresh successful")
+        return new_access
+
+    return None
+
+
+def _authenticate_otp(email: str) -> Dict[str, str]:
+    """Authenticate via WeTransfer passwordless OTP flow.
+
+    Triggers a verification code to the given email, prompts the user
+    to enter it, and exchanges it for Auth0 tokens.
+
+    Return dict with "access_token" and optionally "refresh_token".
+    """
+    logger.debug(f"Requesting OTP code for {email}")
+    data = {"client_id": WETRANSFER_AUTH0_CLIENT_ID, "email": email}
+    r = requests.post(
+        "https://wetransfer.com/adroit/api/v1/login/passwordless",
+        json=data,
+    )
+    r.raise_for_status()
+
+    code = input("Enter the verification code sent to your email: ")
+
+    logger.debug("Exchanging OTP for access_token")
+    data = {
+        "grant_type": "http://auth0.com/oauth/grant-type/passwordless/otp",
+        "client_id": WETRANSFER_AUTH0_CLIENT_ID,
+        "audience": WETRANSFER_AUTH0_AUDIENCE,
+        "otp": code,
+        "realm": "email",
+        "username": email,
+        "scope": "openid offline_access",
+    }
+    r = requests.post(
+        WETRANSFER_AUTH0_URL,
+        headers={
+            "User-Agent": WETRANSFER_USER_AGENT,
+            "x-csrf-token": "csrf-token",
+        },
+        json=data,
+    )
+    r.raise_for_status()
+    logger.debug("OTP authentication successful")
+    token_data = r.json()
+    result = {"access_token": token_data["access_token"]}
+    if "refresh_token" in token_data:
+        result["refresh_token"] = token_data["refresh_token"]
+        logger.debug("Obtained refresh_token for caching")
+    else:
+        logger.debug("No refresh_token returned by Auth0")
+    return result
+
+
+def _authenticate(email: str) -> str:
+    """Authenticate with WeTransfer.
+
+    Tries cached refresh_token first (no user interaction needed).
+    Falls back to passwordless OTP if no cache or refresh fails.
+    Caches tokens after successful OTP for future runs.
+
+    Return access_token.
+    """
+    token = _load_cached_auth(email)
+    if token:
+        return token
+
+    logger.debug("No valid cached token, starting OTP flow")
+    otp_result = _authenticate_otp(email)
+    _save_auth_cache(
+        email,
+        otp_result["access_token"],
+        otp_result.get("refresh_token"),
+    )
+    return otp_result["access_token"]
+
+
 def _prepare_link_upload(
     filenames: List[str],
     display_name: str,
     message: str,
     session: requests.Session,
+    authenticated: bool = False,
 ) -> Dict[Any, Any]:
     """Given a list of filenames and a message prepare for the link upload.
+
+    When authenticated is False, creates an anonymous transfer.
+    When authenticated is True, creates a transfer under the logged-in account.
 
     Return the parsed JSON response.
     """
     j = {
-        "anonymous_transfer": True,
         "files": [_file_name_and_size(f) for f in filenames],
         "display_name": display_name,
         "message": message,
         "ui_language": "en",
     }
+    if not authenticated:
+        j["anonymous_transfer"] = True
 
     r = session.post(WETRANSFER_API_URL, json=j)
     r.raise_for_status()
@@ -549,12 +715,94 @@ def _finalize_upload(
     return r.json()
 
 
+def auth_list() -> None:
+    """List all cached WeTransfer accounts and their token status."""
+    import glob
+    import datetime
+
+    pattern = os.path.join(WETRANSFER_AUTH_CACHE_DIR, "auth_*.json")
+    cache_files = glob.glob(pattern)
+
+    if not cache_files:
+        print("No cached accounts found.")
+        print(f"  Cache directory: {WETRANSFER_AUTH_CACHE_DIR}")
+        print('  Run "transferwee auth <email>" to authenticate.')
+        return
+
+    for cache_file in sorted(cache_files):
+        try:
+            with open(cache_file, "r") as f:
+                cache = json.load(f)
+        except (json.JSONDecodeError, OSError):
+            continue
+
+        email = cache.get("email", "unknown")
+        has_refresh = bool(cache.get("refresh_token"))
+
+        token_info = ""
+        access_token = cache.get("access_token", "")
+        try:
+            payload = json.loads(
+                binascii.a2b_base64(access_token.split(".")[1] + "==")
+            )
+            iat = datetime.datetime.utcfromtimestamp(payload.get("iat", 0))
+            exp = datetime.datetime.utcfromtimestamp(payload.get("exp", 0))
+            now = datetime.datetime.utcnow()
+            if now < exp:
+                token_info = f"access_token valid until {exp:%Y-%m-%d %H:%M} UTC"
+            else:
+                token_info = f"access_token expired ({exp:%Y-%m-%d %H:%M} UTC)"
+            token_info += f", last refreshed {iat:%Y-%m-%d %H:%M} UTC"
+        except Exception:
+            token_info = "could not decode token"
+
+        status = "refresh_token cached" if has_refresh else "no refresh_token"
+        print(f"  {email}")
+        print(f"    status: {status}")
+        print(f"    {token_info}")
+        print(f"    file:   {cache_file}")
+        print()
+
+
+def auth(email: str) -> None:
+    """Authenticate with WeTransfer and cache tokens for future use.
+
+    Triggers the OTP flow (a verification code is sent to the given
+    email) and stores the resulting tokens in the local cache.
+    Subsequent upload calls with the same email will use the cached
+    refresh_token without requiring user interaction.
+    """
+    cached = _load_cached_auth(email)
+    if cached:
+        logger.info(f"Already authenticated as {email} (token refreshed)")
+        return
+
+    logger.info(f"Sending verification code to {email}")
+    otp_result = _authenticate_otp(email)
+    _save_auth_cache(
+        email,
+        otp_result["access_token"],
+        otp_result.get("refresh_token"),
+    )
+    if otp_result.get("refresh_token"):
+        logger.info(
+            f"Authentication successful. Tokens cached to "
+            f"{_auth_cache_path(email)}"
+        )
+    else:
+        logger.info(
+            "Authentication successful but no refresh_token was returned. "
+            "You will need to re-authenticate on every upload."
+        )
+
+
 def upload(
     files: List[str],
     display_name: str = "",
     message: str = "",
     sender: Optional[str] = None,
     recipients: Optional[List[str]] = [],
+    user: Optional[str] = None,
 ) -> str:
     """Given a list of files upload them and return the corresponding URL.
 
@@ -566,9 +814,14 @@ def upload(
                  will be also sent
      - `recipients': list of email addresses of recipients. When the upload
                      succeed every recipients will receive an email with a link
+     - `user': WeTransfer account email for authenticated uploads (a
+               verification code will be sent to this email)
 
     If both sender and recipient parameters are passed the email upload will be
     used. Otherwise, the link upload will be used.
+
+    When user is provided the upload is performed as an authenticated user,
+    which may lift anonymous transfer limits.
 
     Return the short URL of the transfer on success.
     """
@@ -586,11 +839,22 @@ def upload(
     if len(files) != len(set(filenames)):
         raise FileExistsError("Duplicate filenames")
 
+    # Authenticate if credentials were provided
+    auth_token = None
+    if user:
+        logger.debug(f"Authenticating as {user}")
+        auth_token = _authenticate(user)
+        logger.debug("Authentication successful")
+
     logger.debug("Preparing to upload")
     transfer = None
     s = _prepare_session()
     if not s:
         raise ConnectionError("Could not prepare session")
+
+    if auth_token:
+        s.headers.update({"Authorization": f"Bearer {auth_token}"})
+
     if sender and recipients:
         # email upload
         transfer = _prepare_email_upload(
@@ -599,7 +863,10 @@ def upload(
         transfer = _verify_email_upload(transfer, s)
     else:
         # link upload
-        transfer = _prepare_link_upload(files, display_name, message, s)
+        transfer = _prepare_link_upload(
+            files, display_name, message, s,
+            authenticated=auth_token is not None,
+        )
 
     logger.debug(
         "From storm_upload_token WETRANSFER_STORM_PREFLIGHT URL is: "
@@ -678,6 +945,28 @@ if __name__ == "__main__":
         help="URL (we.tl/... or wetransfer.com/downloads/...)",
     )
 
+    # auth subcommand
+    authp = sp.add_parser(
+        "auth",
+        help="authenticate with WeTransfer (OTP via email)",
+    )
+    authp.add_argument(
+        "email",
+        nargs="?",
+        type=str,
+        metavar="email",
+        help="WeTransfer account email to authenticate",
+    )
+    authp.add_argument(
+        "-l",
+        "--list",
+        action="store_true",
+        help="list cached accounts and token status",
+    )
+    authp.add_argument(
+        "-v", action="store_true", help="get verbose/debug logging"
+    )
+
     # upload subcommand
     up = sp.add_parser("upload", help="upload files")
     up.add_argument(
@@ -699,6 +988,14 @@ if __name__ == "__main__":
         "-t", nargs="+", type=str, metavar="to", help="recipient emails"
     )
     up.add_argument(
+        "-u",
+        "--user",
+        type=str,
+        default=os.environ.get("WETRANSFER_USER"),
+        metavar="email",
+        help="WeTransfer account email (or WETRANSFER_USER env var)",
+    )
+    up.add_argument(
         "-v", action="store_true", help="get verbose/debug logging"
     )
     up.add_argument(
@@ -710,6 +1007,15 @@ if __name__ == "__main__":
     if args.v:
         log.setLevel(logging.DEBUG)
 
+    if args.action == "auth":
+        if args.list:
+            auth_list()
+        elif args.email:
+            auth(args.email)
+        else:
+            authp.print_help()
+        exit(0)
+
     if args.action == "download":
         if args.g:
             for u in args.url:
@@ -720,5 +1026,10 @@ if __name__ == "__main__":
         exit(0)
 
     if args.action == "upload":
-        print(upload(args.files, args.n, args.m, args.f, args.t))
+        print(
+            upload(
+                args.files, args.n, args.m, args.f, args.t,
+                args.user,
+            )
+        )
         exit(0)

--- a/transferwee.py
+++ b/transferwee.py
@@ -580,12 +580,11 @@ def _storm_preflight_item(
     """Given a file, prepare the item block dictionary.
 
     Return a dictionary with "blocks", "item_type" and "path" keys.
+    Files larger than STORM_MAX_BLOCK_SIZE are split into multiple blocks.
     """
     filename = _file_display_name(file, path_map)
-    chunks = _file_chunks(file)
-
     return {
-        "blocks": [{"content_length": c["content_length"]} for c in chunks],
+        "blocks": [{"content_length": s["size"]} for s in _file_block_specs(file)],
         "item_type": "file",
         "path": filename,
     }
@@ -620,9 +619,6 @@ def _storm_preflight(
     return r.json()
 
 
-STORM_MAX_BLOCK_SIZE = 15 * 1024 * 1024  # 15 MiB per WeTransfer limit
-
-
 def _md5(file: str) -> str:
     """Given a file, calculate its MD5 checksum.
 
@@ -635,12 +631,36 @@ def _md5(file: str) -> str:
     return h.hexdigest()
 
 
-def _md5_chunk(file: str, offset: int, length: int) -> str:
-    """Given a file, offset and length, calculate MD5 of that chunk."""
+# WeTransfer storm API rejects blocks larger than 15 MB.
+STORM_MAX_BLOCK_SIZE = 15 * 1024 * 1024
+
+
+def _file_block_specs(file: str) -> List[Dict[str, int]]:
+    """Return a list of {offset, size} dicts splitting a file into blocks.
+
+    Each block is at most STORM_MAX_BLOCK_SIZE bytes.
+    """
+    filesize = os.path.getsize(file)
+    if filesize == 0:
+        return [{"offset": 0, "size": 0}]
+    specs: List[Dict[str, int]] = []
+    offset = 0
+    while offset < filesize:
+        size = min(STORM_MAX_BLOCK_SIZE, filesize - offset)
+        specs.append({"offset": offset, "size": size})
+        offset += size
+    return specs
+
+
+def _chunk_md5(file: str, offset: int, size: int) -> str:
+    """Compute MD5 of a specific byte range within a file.
+
+    Return MD5 digest as str.
+    """
     h = hashlib.md5()
     with open(file, "rb") as f:
         f.seek(offset)
-        remaining = length
+        remaining = size
         while remaining > 0:
             data = f.read(min(4096, remaining))
             if not data:
@@ -650,69 +670,68 @@ def _md5_chunk(file: str, offset: int, length: int) -> str:
     return h.hexdigest()
 
 
-def _file_chunks(file: str) -> List[Dict[str, Union[int, str]]]:
-    """Split a file into chunk descriptors for storm upload.
+def _storm_prepare_item(
+    size: int, md5_hex: str,
+) -> Dict[str, Union[int, str]]:
+    """Build a single block entry for the storm blocks API request body.
 
-    Each chunk has offset, content_length and content_md5_hex.
-    Files smaller than STORM_MAX_BLOCK_SIZE produce a single chunk.
+    Return a dictionary with "content_length" and "content_md5_hex" keys.
     """
-    filesize = os.path.getsize(file)
-    if filesize <= STORM_MAX_BLOCK_SIZE:
-        return [{"offset": 0, "content_length": filesize, "content_md5_hex": _md5(file)}]
-    chunks = []
-    offset = 0
-    while offset < filesize:
-        length = min(STORM_MAX_BLOCK_SIZE, filesize - offset)
-        chunks.append({
-            "offset": offset,
-            "content_length": length,
-            "content_md5_hex": _md5_chunk(file, offset, length),
-        })
-        offset += length
-    return chunks
+    return {"content_length": size, "content_md5_hex": md5_hex}
 
 
-def _storm_prepare(
-    authorization: str, filenames: List[str],
-) -> tuple:
-    """Given an Authorization token and filenames prepare for block uploads.
+# Maximum blocks per _storm_prepare API request (server limit is 128).
+_STORM_PREPARE_BATCH_SIZE = 100
 
-    Return (parsed JSON response, list of chunk lists per file).
+
+def _storm_prepare_batch(
+    authorization: str,
+    chunk_specs: List[tuple],
+) -> List[Dict[Any, Any]]:
+    """Register a batch of chunk specs with the storm blocks API.
+
+    chunk_specs is a list of (size, md5_hex) tuples, at most
+    _STORM_PREPARE_BATCH_SIZE items.  Retries up to 8 times with
+    exponential backoff on non-200 responses.
+
+    Return the list of block dicts from the API response.
     """
-    file_chunks = [_file_chunks(f) for f in filenames]
-    all_blocks = []
-    for chunks in file_chunks:
-        for chunk in chunks:
-            all_blocks.append({
-                "content_length": chunk["content_length"],
-                "content_md5_hex": chunk["content_md5_hex"],
-            })
     j = {
-        "blocks": all_blocks,
+        "blocks": [
+            _storm_prepare_item(size, md5_hex)
+            for size, md5_hex in chunk_specs
+        ],
     }
-    requests.options(
-        _storm_urls(authorization)["WETRANSFER_STORM_BLOCK"],
-        headers={
-            "Origin": "https://wetransfer.com",
-            "Access-Control-Request-Method": "POST",
-            "User-Agent": WETRANSFER_USER_AGENT,
-        },
-    )
-    r = requests.post(
-        _storm_urls(authorization)["WETRANSFER_STORM_BLOCK"],
-        json=j,
-        headers={
-            "Authorization": f"Bearer {authorization}",
-            "Origin": "https://wetransfer.com",
-            "User-Agent": WETRANSFER_USER_AGENT,
-        },
-    )
-    resp = r.json()
-    logger.debug(f"_storm_prepare response ({r.status_code}): {resp}")
-    if not resp.get("ok", True) or "data" not in resp:
-        err_msg = resp.get("error", {}).get("message", str(resp))
+    resp = None
+    for attempt in range(8):
+        r = requests.post(
+            _storm_urls(authorization)["WETRANSFER_STORM_BLOCK"],
+            json=j,
+            headers={
+                "Authorization": f"Bearer {authorization}",
+                "Origin": "https://wetransfer.com",
+                "User-Agent": WETRANSFER_USER_AGENT,
+            },
+        )
+        resp = r.json()
+        if r.status_code == 200:
+            n = len(resp.get("data", {}).get("blocks", []))
+            logger.debug(
+                f"_storm_prepare_batch ok: {n} blocks registered"
+            )
+            break
+        logger.debug(
+            f"_storm_prepare_batch {r.status_code}: "
+            f"{resp.get('error', {}).get('message', resp)}"
+        )
+        if attempt < 7:
+            wait = int(r.headers.get("Retry-After", 2 ** attempt))
+            logger.debug(f"  retrying in {wait}s (attempt {attempt + 1}/8)")
+            time.sleep(wait)
+    if not resp or not resp.get("ok", True) or "data" not in resp:
+        err_msg = (resp or {}).get("error", {}).get("message", str(resp))
         raise Exception(f"Storm prepare failed: {err_msg}")
-    return resp, file_chunks
+    return resp["data"]["blocks"]
 
 
 def _storm_finalize_item(
@@ -733,18 +752,18 @@ def _storm_finalize_item(
 
 def _storm_finalize(
     authorization: str, filenames: List[str],
-    file_block_ids: List[List[str]],
+    block_ids_per_file: List[List[str]],
     path_map: Dict[str, str] = {},
 ) -> Dict[Any, Any]:
-    """Given an Authorization token, filenames and block ids finalize upload.
+    """Given an Authorization token, filenames and per-file block id lists,
+    finalize the upload.
 
-    file_block_ids is a list of lists: one list of block_ids per file.
     Return the parsed JSON response.
     """
     j = {
         "items": [
             _storm_finalize_item(f, bids, path_map)
-            for f, bids in zip(filenames, file_block_ids)
+            for f, bids in zip(filenames, block_ids_per_file)
         ],
     }
     requests.options(
@@ -782,18 +801,16 @@ def _storm_finalize(
     return r.json()
 
 
-def _storm_upload(
-    url: str, file: str,
-    offset: int = 0, length: int = 0, md5_hex: str = "",
+def _storm_upload_chunk(
+    url: str, file: str, offset: int, size: int, md5_hex: str,
 ) -> None:
-    """Given an url and file (or chunk) upload it.
+    """Upload a single chunk of a file to a presigned URL.
 
-    When offset/length/md5_hex are provided, only that portion is uploaded.
-    Otherwise the entire file is uploaded.
+    md5_hex is the pre-computed hex MD5 of the chunk (reused from prepare
+    to avoid reading the chunk twice from disk).
+
+    Does not return anything.
     """
-    if not md5_hex:
-        md5_hex = _md5(file)
-        length = os.path.getsize(file)
     requests.options(
         url,
         headers={
@@ -804,19 +821,19 @@ def _storm_upload(
     )
     with open(file, "rb") as f:
         f.seek(offset)
-        data = f.read(length)
-        requests.put(
-            url,
-            data=data,
-            headers={
-                "Origin": "https://wetransfer.com",
-                "Content-MD5": binascii.b2a_base64(
-                    binascii.unhexlify(md5_hex), newline=False
-                ),
-                "X-Uploader": "storm",
-                "User-Agent": WETRANSFER_USER_AGENT,
-            },
-        )
+        data = f.read(size)
+    requests.put(
+        url,
+        data=data,
+        headers={
+            "Origin": "https://wetransfer.com",
+            "Content-MD5": binascii.b2a_base64(
+                binascii.unhexlify(md5_hex), newline=False
+            ),
+            "X-Uploader": "storm",
+            "User-Agent": WETRANSFER_USER_AGENT,
+        },
+    )
 
 
 def _finalize_upload(
@@ -824,16 +841,31 @@ def _finalize_upload(
 ) -> Dict[Any, Any]:
     """Given a transfer_id finalize the upload.
 
-    Return the parsed JSON response.
+    Retries up to 8 times with exponential backoff when the response
+    does not yet contain a shortened_url (the server may still be
+    processing the uploaded blocks).
+
+    Return the parsed JSON response containing shortened_url.
     """
     j = {
         "wants_storm": True,
     }
-    r = session.put(
-        WETRANSFER_FINALIZE_URL.format(transfer_id=transfer_id), json=j
+    url = WETRANSFER_FINALIZE_URL.format(transfer_id=transfer_id)
+    for attempt in range(8):
+        r = session.put(url, json=j)
+        resp = r.json()
+        logger.debug(f"_finalize_upload ({r.status_code}): {resp}")
+        if r.status_code == 200 and "shortened_url" in resp:
+            return resp
+        wait = 2 ** attempt
+        logger.debug(
+            f"_finalize_upload: shortened_url not ready, "
+            f"retrying in {wait}s (attempt {attempt + 1}/8)"
+        )
+        time.sleep(wait)
+    raise Exception(
+        f"Finalize upload failed after 8 attempts: {resp}"
     )
-
-    return r.json()
 
 
 def auth_list() -> None:
@@ -1059,32 +1091,63 @@ def upload(
     logger.debug(f"Get transfer id {transfer['id']}")
     logger.debug("Doing preflight storm")
     _storm_preflight(transfer["storm_upload_token"], files, path_map)
-    logger.debug("Preparing storm block upload")
-    resp, file_chunks = _storm_prepare(transfer["storm_upload_token"], files)
-    api_blocks = resp["data"]["blocks"]
-    block_idx = 0
-    file_block_ids = []
-    for f, chunks in zip(files, file_chunks):
-        block_ids = []
-        for chunk in chunks:
-            b = api_blocks[block_idx]
-            logger.debug(
-                f"Uploading {f} chunk offset={chunk['offset']} "
-                f"size={chunk['content_length']}"
+
+    auth_token = transfer["storm_upload_token"]
+    requests.options(
+        _storm_urls(auth_token)["WETRANSFER_STORM_BLOCK"],
+        headers={
+            "Origin": "https://wetransfer.com",
+            "Access-Control-Request-Method": "POST",
+            "User-Agent": WETRANSFER_USER_AGENT,
+        },
+    )
+
+    # Process files in a streaming fashion: for each file, compute chunk
+    # MD5s, register the blocks, upload each chunk immediately, then move
+    # on.  This avoids presigned URL expiry (must_upload_in_seconds=900)
+    # that would occur if all blocks were registered up-front.
+    block_ids_per_file: List[List[str]] = []
+    for file_idx, f in enumerate(files):
+        specs = _file_block_specs(f)
+        logger.debug(
+            f"[{file_idx + 1}/{len(files)}] {f} "
+            f"({len(specs)} chunk{'s' if len(specs) != 1 else ''})"
+        )
+
+        # Compute MD5 once per chunk; reused for both prepare and upload.
+        chunk_md5s = [
+            _chunk_md5(f, s["offset"], s["size"]) for s in specs
+        ]
+        prepare_specs = [
+            (s["size"], md5) for s, md5 in zip(specs, chunk_md5s)
+        ]
+
+        # Register blocks in batches of _STORM_PREPARE_BATCH_SIZE.
+        file_block_results: List[Dict[Any, Any]] = []
+        for i in range(0, len(prepare_specs), _STORM_PREPARE_BATCH_SIZE):
+            batch = prepare_specs[i:i + _STORM_PREPARE_BATCH_SIZE]
+            file_block_results.extend(
+                _storm_prepare_batch(auth_token, batch)
             )
-            _storm_upload(
-                b["presigned_put_url"], f,
-                chunk["offset"], chunk["content_length"], chunk["content_md5_hex"],
+
+        # Upload each chunk right away using the fresh presigned URLs.
+        file_block_ids: List[str] = []
+        total_chunks = len(specs)
+        for chunk_idx, (block, spec, md5_hex) in enumerate(
+            zip(file_block_results, specs, chunk_md5s)
+        ):
+            pct = (chunk_idx + 1) * 100 // total_chunks
+            logger.debug(f"  chunk {chunk_idx + 1}/{total_chunks} ({pct}%)")
+            _storm_upload_chunk(
+                block["presigned_put_url"], f, spec["offset"], spec["size"],
+                md5_hex,
             )
-            block_ids.append(b["block_id"])
-            block_idx += 1
-        file_block_ids.append(block_ids)
+            file_block_ids.append(block["block_id"])
+        block_ids_per_file.append(file_block_ids)
+
     logger.debug("Finalizing storm batch upload")
     _storm_finalize(
-        transfer["storm_upload_token"],
-        files,
-        file_block_ids,
-        path_map,
+        auth_token, files, block_ids_per_file, path_map,
     )
     logger.debug(f"Finalizing upload with transfer id {transfer['id']}")
     shortened_url = _finalize_upload(transfer["id"], s)["shortened_url"]


### PR DESCRIPTION
## Summary

- Add support for authenticated uploads via `-u/--user` option, which avoids the transfer limits imposed on anonymous users
- New `auth` subcommand to authenticate with WeTransfer via passwordless OTP (a verification code is sent to the user's email)
- Token caching with automatic refresh: after a one-time OTP verification, the refresh_token is cached locally under `~/.config/transferwee/` so subsequent uploads run without user interaction
- Multi-account support: each account gets its own cache file, allowing users to manage multiple WeTransfer accounts
`auth -l / auth --list` shows all cached accounts with token status and expiry information
- Auth0 client_id and audience are configurable via `--client-id` and `--audience `flags on the auth subcommand, with overrides persisted to `~/.config/transferwee/oauth_config.json`
- Updated README with documentation for auth, authenticated uploads, and OAuth configuration

## Motivation
Anonymous transfers on wetransfer.com are subject to size and rate limits that registered users do not have. This change allows transferwee to operate as an authenticated user, making it suitable for automated/scripted use (e.g. on a NAS) where the OTP only needs to be entered once.

## Usage
```
# One-time authentication (sends OTP to email)
transferwee auth user@example.com

# Authenticated upload (uses cached token, no interaction needed)
transferwee upload -u user@example.com file.zip

# List cached accounts
transferwee auth -l

# Or use the environment variable
export WETRANSFER_USER=user@example.com
transferwee upload file.zip
```
## Concerns
The Auth0 client_id and audience values were extracted from WeTransfer's web application. These are not part of any public API and could change at any time without notice. If WeTransfer updates their Auth0 configuration, the token refresh and OTP flows will break with an invalid_client_id error.

To mitigate this, the values are configurable without code changes:

`transferwee auth --client-id NEW_ID --audience NEW_URL user@example.com`

Overrides are persisted to ~/.config/transferwee/oauth_config.json and used for all subsequent operations.